### PR TITLE
Add support for batch_matrix_multiply + some cleaning up

### DIFF
--- a/samples/compiler_plugins/xnnpack/src/xnnpack_sample/IR/XnnpackOps.td
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack_sample/IR/XnnpackOps.td
@@ -18,8 +18,19 @@ class Xnnpack_Op<string mnemonic, list<Trait> traits = []> :
     Op<Xnnpack_Dialect, mnemonic, traits> {
 }
 
-def Xnnpack_Mul2Op : Xnnpack_Op<"mul2", []> {
+def Xnnpack_Multiply2Op : Xnnpack_Op<"multiply2", []> {
   let summary = "Elementwise multiplication";
+  let arguments = (ins AnyRankedTensor:$a,
+                       AnyRankedTensor:$b);
+  let results = (outs AnyRankedTensor:$result);
+
+  let assemblyFormat = [{
+    $a `,` $b attr-dict `:` functional-type(operands, results)
+  }];
+}
+
+def Xnnpack_BatchMatrixMultiplyOp : Xnnpack_Op<"batch_matrix_multiply", []> {
+  let summary = "Batch matrix multiplication";
   let arguments = (ins AnyRankedTensor:$a,
                        AnyRankedTensor:$b);
   let results = (outs AnyRankedTensor:$result);

--- a/samples/compiler_plugins/xnnpack/test/BUILD.bazel
+++ b/samples/compiler_plugins/xnnpack/test/BUILD.bazel
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     srcs = enforce_glob(
         [
             "mul2-1d-e2e.mlir",
+            "batch_matrix_multiply_e2e.mlir",
             "xnnpack-legalize.mlir",
         ],
         include = ["*.mlir"],

--- a/samples/compiler_plugins/xnnpack/test/CMakeLists.txt
+++ b/samples/compiler_plugins/xnnpack/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "batch_matrix_multiply_e2e.mlir"
     "mul2-1d-e2e.mlir"
     "xnnpack-legalize.mlir"
   TOOLS

--- a/samples/compiler_plugins/xnnpack/test/batch_matrix_multiply_e2e.mlir
+++ b/samples/compiler_plugins/xnnpack/test/batch_matrix_multiply_e2e.mlir
@@ -1,0 +1,18 @@
+// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --iree-plugin=xnnpack_sample %s | \
+// RUN: iree-run-module \
+// RUN:     --device=local-sync \
+// RUN:     --executable_plugin=$IREE_BINARY_DIR/samples/custom_dispatch/xnnpack/plugin/system_plugin$IREE_DYLIB_EXT \
+// RUN:     --module=- \
+// RUN:     --function=main \
+// RUN:     --input=2x2x2xf32=2 \
+// RUN:     --input=2x2x2xf32=4 | \
+// llvm-lit does not like checking for '[['
+// RUN:     sed 's/\[/(/g' | \
+// RUN: FileCheck %s --check-prefix=CHECK-SYSTEM
+
+// CHECK-SYSTEM: EXEC @main
+// CHECK-SYSTEM: 2x2x2xf32=((16 16](16 16]]((16 16](16 16]]
+func.func @main(%a : tensor<?x2x2xf32>, %b : tensor<?x2x2xf32>) -> tensor<?x2x2xf32> {
+  %c = xnnpack.batch_matrix_multiply %a, %b : (tensor<?x2x2xf32>, tensor<?x2x2xf32>) -> tensor<?x2x2xf32>
+  func.return %c : tensor<?x2x2xf32>
+}

--- a/samples/compiler_plugins/xnnpack/test/mul2-1d-e2e.mlir
+++ b/samples/compiler_plugins/xnnpack/test/mul2-1d-e2e.mlir
@@ -19,6 +19,6 @@
 // CHECK-SYSTEM: mul2[7](2 * 4 = 8)
 // CHECK-SYSTEM: 8xf32=8 8 8 8 8 8 8 8
 func.func @main(%a : tensor<?xf32>, %b : tensor<?xf32>) -> tensor<?xf32> {
-  %c = xnnpack.mul2 %a, %b : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+  %c = xnnpack.multiply2 %a, %b : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
   func.return %c : tensor<?xf32>
 }

--- a/samples/compiler_plugins/xnnpack/test/xnnpack-legalize.mlir
+++ b/samples/compiler_plugins/xnnpack/test/xnnpack-legalize.mlir
@@ -1,22 +1,40 @@
 // RUN: iree-opt --iree-plugin=xnnpack_sample --iree-print-plugin-info --pass-pipeline='builtin.module(iree-xnnpack-legalize)' %s | FileCheck %s
 
-// CHECK-LABEL:   func.func private @xnnpack.mul2(
-// CHECK-SAME:                                    %[[VAL_0:.*]]: tensor<?xf32>,
-// CHECK-SAME:                                    %[[VAL_1:.*]]: tensor<?xf32>) -> tensor<?xf32> {
-// CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
-// CHECK:           %[[VAL_3:.*]] = tensor.dim %[[VAL_0]], %[[VAL_2]] : tensor<?xf32>
-// CHECK:           %[[VAL_4:.*]] = tensor.empty(%[[VAL_3]]) : tensor<?xf32>
-// CHECK:           %[[VAL_5:.*]] = flow.dispatch.region -> (tensor<?xf32>{%[[VAL_3]]}) {
-// CHECK:             %[[VAL_6:.*]] = iree_codegen.ukernel.generic "xnnpack.mul2_workgroup" ins(%[[VAL_0]], %[[VAL_1]] : tensor<?xf32>, tensor<?xf32>) outs(%[[VAL_4]] : tensor<?xf32>) (%[[VAL_3]] : index) -> tensor<?xf32>
-// CHECK:             flow.return %[[VAL_6]] : tensor<?xf32>
-// CHECK:           } count() -> (index, index, index) {
-// CHECK:             %[[VAL_7:.*]] = arith.constant 1 : index
-// CHECK:             flow.return %[[VAL_7]], %[[VAL_7]], %[[VAL_7]] : index, index, index
-// CHECK:           return %[[VAL_5]] : tensor<?xf32>
+// CHECK-LABEL:   func.func private @xnnpack.multiply2(
+// CHECK-SAME:                                    %[[A:.*]]: tensor<?xf32>,
+// CHECK-SAME:                                    %[[B:.*]]: tensor<?xf32>) -> tensor<?xf32> {
+// CHECK:           %[[OUT:.*]] = tensor.empty(%[[A_DIM:.*]]) : tensor<?xf32>
+// CHECK:           %[[RESULT:.*]] = flow.dispatch.region -> (tensor<?xf32>{%[[A_DIM]]}) {
+// CHECK:             %[[UKERNEL:.*]] = iree_codegen.ukernel.generic "xnnpack.multiply2_workgroup" ins(%[[A]], %[[B]] : tensor<?xf32>, tensor<?xf32>) outs(%[[OUT]] : tensor<?xf32>) (%[[A_DIM]], %[[B_DIM:.*]], %[[A_DIM]] : index, index, index) -> tensor<?xf32>
+// CHECK:             flow.return %[[UKERNEL]] : tensor<?xf32>
+// CHECK:           } count()
+// CHECK:             %[[ONE:.*]] = arith.constant 1 : index
+// CHECK:             flow.return %[[ONE]], %[[ONE]], %[[ONE]]
+// CHECK:           return %[[RESULT]] : tensor<?xf32>
 
-// CHECK-LABEL:   func.func @main(
-// CHECK:           %[[VAL_2:.*]] = call @xnnpack.mul2(%[[VAL_0]], %[[VAL_1]])
-func.func @main(%a : tensor<?xf32>, %b : tensor<?xf32>) -> tensor<?xf32> {
-  %c = xnnpack.mul2 %a, %b : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+// CHECK-LABEL:   func.func private @xnnpack.batch_matrix_multiply(
+// CHECK-SAME:                                      %[[A:.*]]: tensor<?x?x?xf32>,
+// CHECK-SAME:                                      %[[B:.*]]: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
+// CHECK:           %[[OUT:.*]] = tensor.empty(%[[A_DIM_0:.*]], %[[A_DIM_1:.*]], %[[B_DIM_2:.*]]) : tensor<?x?x?xf32>
+// CHECK:           %[[RESULT:.*]] = flow.dispatch.region -> (tensor<?x?x?xf32>{%[[A_DIM_0]], %[[A_DIM_1]], %[[B_DIM_2]]}) {
+// CHECK:             %[[UKERNEL:.*]] = iree_codegen.ukernel.generic "xnnpack.batch_matrix_multiply_workgroup" ins(%[[A]], %[[B]] : tensor<?x?x?xf32>, tensor<?x?x?xf32>) outs(%[[OUT]] : tensor<?x?x?xf32>) (%[[A_DIM_0]], %[[A_DIM_1]], %[[A_DIM_2:.*]], %[[B_DIM_0:.*]], %[[B_DIM_1:.*]], %[[B_DIM_2]], %[[A_DIM_0]], %[[A_DIM_1]], %[[B_DIM_2]] : index, index, index, index, index, index, index, index, index) -> tensor<?x?x?xf32>
+// CHECK:             flow.return %[[UKERNEL]] : tensor<?x?x?xf32>
+// CHECK:           } count()
+// CHECK:             %[[ONE:.*]] = arith.constant 1 : index
+// CHECK:             flow.return %[[ONE]], %[[ONE]], %[[ONE]]
+// CHECK:           }
+// CHECK:           return %[[RESULT]] : tensor<?x?x?xf32>
+
+// CHECK-LABEL:   func.func @multiply2(
+// CHECK:           %[[VAL_2:.*]] = call @xnnpack.multiply2
+func.func @multiply2(%a : tensor<?xf32>, %b : tensor<?xf32>) -> tensor<?xf32> {
+  %c = xnnpack.multiply2 %a, %b : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
   func.return %c : tensor<?xf32>
+}
+
+// CHECK-LABEL:   func.func @batch_matrix_multiply(
+// CHECK:           %[[VAL_2:.*]] = call @xnnpack.batch_matrix_multiply
+func.func @batch_matrix_multiply(%a : tensor<?x?x?xf32>, %b : tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
+  %c = xnnpack.batch_matrix_multiply %a, %b : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
+  func.return %c : tensor<?x?x?xf32>
 }


### PR DESCRIPTION
This commit adds support for `xnnpack.batch_matrix_multiply`. It also makes the naming of ops consistent with xnnpack, i.e. `mul2` got renamed to `multiply_2`.