### PR TITLE
Add skeleton for StablehloToXnnpack pass

### DIFF
--- a/samples/compiler_plugins/xnnpack/BUILD.bazel
+++ b/samples/compiler_plugins/xnnpack/BUILD.bazel
@@ -23,9 +23,9 @@ cc_library(
         "src/PluginRegistration.cpp",
     ],
     deps = [
+        ":Conversion",
         ":IR",
         ":Transforms",
-        ":Conversion",
         ":defs",
         "//compiler/src/iree/compiler/PluginAPI",
         "@llvm-project//mlir:IR",
@@ -41,9 +41,9 @@ iree_compiler_register_plugin(
 iree_td_library(
     name = "td_files",
     srcs = [
+        "src/xnnpack_sample/Conversion/Passes.td",
         "src/xnnpack_sample/IR/XnnpackOps.td",
         "src/xnnpack_sample/Transforms/Passes.td",
-        "src/xnnpack_sample/Conversion/Passes.td",
     ],
     deps = [
         "@llvm-project//mlir:ControlFlowInterfacesTdFiles",
@@ -105,8 +105,8 @@ iree_gentbl_cc_library(
 cc_library(
     name = "Transforms",
     srcs = [
-        "src/xnnpack_sample/Transforms/Passes.cpp",
         "src/xnnpack_sample/Transforms/LegalizeXnnpack.cpp",
+        "src/xnnpack_sample/Transforms/Passes.cpp",
     ],
     hdrs = [
         "src/xnnpack_sample/Transforms/Passes.h",
@@ -135,8 +135,8 @@ cc_library(
         "src/xnnpack_sample/Conversion/Passes.h.inc",
     ],
     deps = [
-        ":IR",
         ":ConversionPassesIncGen",
+        ":IR",
         "@llvm-project//mlir:Transforms",
         "@stablehlo//:stablehlo_ops",
     ],

--- a/samples/compiler_plugins/xnnpack/BUILD.bazel
+++ b/samples/compiler_plugins/xnnpack/BUILD.bazel
@@ -126,6 +126,7 @@ cc_library(
 cc_library(
     name = "Conversion",
     srcs = [
+        "src/xnnpack_sample/Conversion/Passes.cpp",
         "src/xnnpack_sample/Conversion/StablehloToXnnpack.cpp",
     ],
     hdrs = [
@@ -133,9 +134,10 @@ cc_library(
         "src/xnnpack_sample/Conversion/Passes.h.inc",
     ],
     deps = [
+        ":IR",
         ":ConversionPassesIncGen",
-        ":defs",
-        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Transforms",
+        "@stablehlo//:stablehlo_ops",
     ],
 )
 

--- a/samples/compiler_plugins/xnnpack/BUILD.bazel
+++ b/samples/compiler_plugins/xnnpack/BUILD.bazel
@@ -25,6 +25,7 @@ cc_library(
     deps = [
         ":IR",
         ":Transforms",
+        ":Conversion",
         ":defs",
         "//compiler/src/iree/compiler/PluginAPI",
         "@llvm-project//mlir:IR",
@@ -42,6 +43,7 @@ iree_td_library(
     srcs = [
         "src/xnnpack_sample/IR/XnnpackOps.td",
         "src/xnnpack_sample/Transforms/Passes.td",
+        "src/xnnpack_sample/Conversion/Passes.td",
     ],
     deps = [
         "@llvm-project//mlir:ControlFlowInterfacesTdFiles",
@@ -111,7 +113,7 @@ cc_library(
     ],
     deps = [
         ":IR",
-        ":PassesIncGen",
+        ":TransformsPassesIncGen",
         ":defs",
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
         "//compiler/src/iree/compiler/Dialect/Flow/IR",
@@ -121,8 +123,24 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "Conversion",
+    srcs = [
+        "src/xnnpack_sample/Conversion/StablehloToXnnpack.cpp",
+    ],
+    hdrs = [
+        "src/xnnpack_sample/Conversion/Passes.h",
+        "src/xnnpack_sample/Conversion/Passes.h.inc",
+    ],
+    deps = [
+        ":ConversionPassesIncGen",
+        ":defs",
+        "@llvm-project//mlir:IR",
+    ],
+)
+
 iree_gentbl_cc_library(
-    name = "PassesIncGen",
+    name = "TransformsPassesIncGen",
     tbl_outs = [
         (
             ["--gen-pass-decls"],
@@ -131,6 +149,22 @@ iree_gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "src/xnnpack_sample/Transforms/Passes.td",
+    deps = [
+        ":td_files",
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
+)
+
+iree_gentbl_cc_library(
+    name = "ConversionPassesIncGen",
+    tbl_outs = [
+        (
+            ["--gen-pass-decls"],
+            "src/xnnpack_sample/Conversion/Passes.h.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "src/xnnpack_sample/Conversion/Passes.td",
     deps = [
         ":td_files",
         "@llvm-project//mlir:PassBaseTdFiles",

--- a/samples/compiler_plugins/xnnpack/BUILD.bazel
+++ b/samples/compiler_plugins/xnnpack/BUILD.bazel
@@ -105,6 +105,7 @@ iree_gentbl_cc_library(
 cc_library(
     name = "Transforms",
     srcs = [
+        "src/xnnpack_sample/Transforms/Passes.cpp",
         "src/xnnpack_sample/Transforms/LegalizeXnnpack.cpp",
     ],
     hdrs = [

--- a/samples/compiler_plugins/xnnpack/CMakeLists.txt
+++ b/samples/compiler_plugins/xnnpack/CMakeLists.txt
@@ -83,6 +83,7 @@ iree_cc_library(
     "src/xnnpack_sample/Transforms/Passes.h.inc"
   SRCS
     "src/xnnpack_sample/Transforms/LegalizeXnnpack.cpp"
+    "src/xnnpack_sample/Transforms/Passes.cpp"
   DEPS
     ::IR
     ::TransformsPassesIncGen

--- a/samples/compiler_plugins/xnnpack/CMakeLists.txt
+++ b/samples/compiler_plugins/xnnpack/CMakeLists.txt
@@ -102,11 +102,13 @@ iree_cc_library(
     "src/xnnpack_sample/Conversion/Passes.h"
     "src/xnnpack_sample/Conversion/Passes.h.inc"
   SRCS
+    "src/xnnpack_sample/Conversion/Passes.cpp"
     "src/xnnpack_sample/Conversion/StablehloToXnnpack.cpp"
   DEPS
     ::ConversionPassesIncGen
-    ::defs
-    MLIRIR
+    ::IR
+    MLIRTransforms
+    StablehloOps
   PUBLIC
 )
 

--- a/samples/compiler_plugins/xnnpack/CMakeLists.txt
+++ b/samples/compiler_plugins/xnnpack/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_cc_library(
   SRCS
     "src/PluginRegistration.cpp"
   DEPS
+    ::Conversion
     ::IR
     ::Transforms
     ::defs
@@ -84,7 +85,7 @@ iree_cc_library(
     "src/xnnpack_sample/Transforms/LegalizeXnnpack.cpp"
   DEPS
     ::IR
-    ::PassesIncGen
+    ::TransformsPassesIncGen
     ::defs
     MLIRFuncDialect
     MLIRIR
@@ -94,13 +95,37 @@ iree_cc_library(
   PUBLIC
 )
 
+iree_cc_library(
+  NAME
+    Conversion
+  HDRS
+    "src/xnnpack_sample/Conversion/Passes.h"
+    "src/xnnpack_sample/Conversion/Passes.h.inc"
+  SRCS
+    "src/xnnpack_sample/Conversion/StablehloToXnnpack.cpp"
+  DEPS
+    ::ConversionPassesIncGen
+    ::defs
+    MLIRIR
+  PUBLIC
+)
+
 iree_tablegen_library(
   NAME
-    PassesIncGen
+    TransformsPassesIncGen
   TD_FILE
     "src/xnnpack_sample/Transforms/Passes.td"
   OUTS
     --gen-pass-decls src/xnnpack_sample/Transforms/Passes.h.inc
+)
+
+iree_tablegen_library(
+  NAME
+    ConversionPassesIncGen
+  TD_FILE
+    "src/xnnpack_sample/Conversion/Passes.td"
+  OUTS
+    --gen-pass-decls src/xnnpack_sample/Conversion/Passes.h.inc
 )
 
 iree_tablegen_doc(

--- a/samples/compiler_plugins/xnnpack/src/PluginRegistration.cpp
+++ b/samples/compiler_plugins/xnnpack/src/PluginRegistration.cpp
@@ -14,15 +14,6 @@
 using namespace mlir;
 using namespace mlir::iree_compiler;
 
-namespace detail {
-namespace {
-
-#define GEN_PASS_REGISTRATION
-#include "xnnpack_sample/Transforms/Passes.h.inc"
-
-}  // namespace
-}  // namespace detail
-
 namespace {
 
 struct MyOptions {
@@ -31,7 +22,7 @@ struct MyOptions {
 
 struct MySession : public PluginSession<MySession, MyOptions> {
   static void registerPasses() {
-    ::detail::registerPasses();
+    IREE::Xnnpack::registerXnnpackPluginTransformsPasses();
     IREE::Xnnpack::registerXnnpackPluginConversionPasses();
   }
 

--- a/samples/compiler_plugins/xnnpack/src/xnnpack_sample/Conversion/Passes.cpp
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack_sample/Conversion/Passes.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 The IREE Authors
+// Copyright 2024 The IREE Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/samples/compiler_plugins/xnnpack/src/xnnpack_sample/Conversion/Passes.cpp
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack_sample/Conversion/Passes.cpp
@@ -1,0 +1,20 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "xnnpack_sample/Conversion/Passes.h"
+
+namespace mlir::iree_compiler::IREE::Xnnpack {
+namespace {
+#define GEN_PASS_REGISTRATION
+#include "xnnpack_sample/Conversion/Passes.h.inc"
+}  // namespace
+
+void registerXnnpackPluginConversionPasses() {
+  // Generated.
+  registerPasses();
+}
+
+}  // namespace mlir::iree_compiler::IREE::Xnnpack

--- a/samples/compiler_plugins/xnnpack/src/xnnpack_sample/Conversion/Passes.h
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack_sample/Conversion/Passes.h
@@ -15,6 +15,8 @@ namespace mlir::iree_compiler::IREE::Xnnpack {
 
 std::unique_ptr<OperationPass<ModuleOp>> createConvertStablehloToXnnpackPass();
 
+void registerXnnpackPluginConversionPasses();
+
 }  // namespace mlir::iree_compiler::IREE::Xnnpack
 
 #endif  // IREE_SAMPLES_COMPILER_PLUGINS_XNNPACK_SAMPLE_CONVERSION_PASSES_H_

--- a/samples/compiler_plugins/xnnpack/src/xnnpack_sample/Conversion/Passes.h
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack_sample/Conversion/Passes.h
@@ -1,4 +1,4 @@
-// Copyright 2023 The IREE Authors
+// Copyright 2024 The IREE Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/samples/compiler_plugins/xnnpack/src/xnnpack_sample/Conversion/Passes.h
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack_sample/Conversion/Passes.h
@@ -1,0 +1,20 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_SAMPLES_COMPILER_PLUGINS_XNNPACK_SAMPLE_CONVERSION_PASSES_H_
+#define IREE_SAMPLES_COMPILER_PLUGINS_XNNPACK_SAMPLE_CONVERSION_PASSES_H_
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+
+namespace mlir::iree_compiler::IREE::Xnnpack {
+
+std::unique_ptr<OperationPass<ModuleOp>> createConvertStablehloToXnnpackPass();
+
+}  // namespace mlir::iree_compiler::IREE::Xnnpack
+
+#endif  // IREE_SAMPLES_COMPILER_PLUGINS_XNNPACK_SAMPLE_CONVERSION_PASSES_H_

--- a/samples/compiler_plugins/xnnpack/src/xnnpack_sample/Conversion/Passes.td
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack_sample/Conversion/Passes.td
@@ -1,0 +1,19 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+include "mlir/Pass/PassBase.td"
+
+#ifndef IREE_XNNPACK_CONVERSION_PASSES
+#define IREE_XNNPACK_CONVERSION_PASSES
+
+def ConvertStablehloToXnnpack : Pass<"iree-stablehlo-to-xnnpack", "mlir::ModuleOp"> {
+  let summary = "Convert StableHLO ops to XNNPACK dialect ops";
+  let constructor = [{
+    ::mlir::iree_compiler::IREE::Xnnpack::createConvertStablehloToXnnpackPass()
+  }];
+}
+
+#endif // IREE_XNNPACK_CONVERSION_PASSES

--- a/samples/compiler_plugins/xnnpack/src/xnnpack_sample/Conversion/Passes.td
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack_sample/Conversion/Passes.td
@@ -1,4 +1,4 @@
-// Copyright 2023 The IREE Authors
+// Copyright 2024 The IREE Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/samples/compiler_plugins/xnnpack/src/xnnpack_sample/Conversion/StablehloToXnnpack.cpp
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack_sample/Conversion/StablehloToXnnpack.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 The IREE Authors
+// Copyright 2024 The IREE Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/samples/compiler_plugins/xnnpack/src/xnnpack_sample/Conversion/StablehloToXnnpack.cpp
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack_sample/Conversion/StablehloToXnnpack.cpp
@@ -1,0 +1,28 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "xnnpack_sample/Conversion/Passes.h"
+
+#define GEN_PASS_DEF_CONVERTSTABLEHLOTOXNNPACK
+#include "xnnpack_sample/Conversion/Passes.h.inc"
+
+namespace mlir::iree_compiler::IREE::Xnnpack {
+namespace {
+class ConvertStablehloToXnnpackPass
+    : public ::impl::ConvertStablehloToXnnpackBase<
+          ConvertStablehloToXnnpackPass> {
+ public:
+  void getDependentDialects(DialectRegistry &registry) const override {}
+  void runOnOperation() override {}
+};
+
+}  // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>> createConvertStablehloToXnnpackPass() {
+  return std::make_unique<ConvertStablehloToXnnpackPass>();
+}
+
+}  // namespace mlir::iree_compiler::IREE::Xnnpack

--- a/samples/compiler_plugins/xnnpack/src/xnnpack_sample/Conversion/StablehloToXnnpack.cpp
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack_sample/Conversion/StablehloToXnnpack.cpp
@@ -4,19 +4,55 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "mlir/Transforms/DialectConversion.h"
+#include "stablehlo/dialect/StablehloOps.h"
 #include "xnnpack_sample/Conversion/Passes.h"
+#include "xnnpack_sample/IR/XnnpackDialect.h"
+#include "xnnpack_sample/IR/XnnpackOps.h"
 
 #define GEN_PASS_DEF_CONVERTSTABLEHLOTOXNNPACK
 #include "xnnpack_sample/Conversion/Passes.h.inc"
 
 namespace mlir::iree_compiler::IREE::Xnnpack {
 namespace {
+class ConvertDotGeneralOp
+    : public OpConversionPattern<mlir::stablehlo::DotGeneralOp> {
+ public:
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      mlir::stablehlo::DotGeneralOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    Value lhs = adaptor.getLhs();
+    Value rhs = adaptor.getRhs();
+    rewriter.replaceOpWithNewOp<Xnnpack::BatchMatrixMultiplyOp>(
+        op, op.getType(), lhs, rhs);
+    return success();
+  }
+};
+}  // namespace
+
+namespace {
 class ConvertStablehloToXnnpackPass
     : public ::impl::ConvertStablehloToXnnpackBase<
           ConvertStablehloToXnnpackPass> {
  public:
-  void getDependentDialects(DialectRegistry &registry) const override {}
-  void runOnOperation() override {}
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<IREE::Xnnpack::XnnpackDialect>();
+  }
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ConversionTarget target(*context);
+    target.addLegalDialect<IREE::Xnnpack::XnnpackDialect>();
+    TypeConverter typeConverter;
+    typeConverter.addConversion([](Type type) { return type; });
+    RewritePatternSet patterns(context);
+    patterns.add<ConvertDotGeneralOp>(typeConverter, context);
+    target.addIllegalOp<stablehlo::DotGeneralOp>();
+
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns))))
+      return signalPassFailure();
+  }
 };
 
 }  // namespace

--- a/samples/compiler_plugins/xnnpack/src/xnnpack_sample/Transforms/Passes.cpp
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack_sample/Transforms/Passes.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 The IREE Authors
+// Copyright 2024 The IREE Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/samples/compiler_plugins/xnnpack/src/xnnpack_sample/Transforms/Passes.cpp
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack_sample/Transforms/Passes.cpp
@@ -1,0 +1,20 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "xnnpack_sample/Transforms/Passes.h"
+
+namespace mlir::iree_compiler::IREE::Xnnpack {
+namespace {
+#define GEN_PASS_REGISTRATION
+#include "xnnpack_sample/Transforms/Passes.h.inc"
+}  // namespace
+
+void registerXnnpackPluginTransformsPasses() {
+  // Generated.
+  registerPasses();
+}
+
+}  // namespace mlir::iree_compiler::IREE::Xnnpack

--- a/samples/compiler_plugins/xnnpack/src/xnnpack_sample/Transforms/Passes.h
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack_sample/Transforms/Passes.h
@@ -15,6 +15,8 @@ namespace mlir::iree_compiler::IREE::Xnnpack {
 
 std::unique_ptr<OperationPass<ModuleOp>> createLegalizeXnnpackPass();
 
+void registerXnnpackPluginTransformsPasses();
+
 }  // namespace mlir::iree_compiler::IREE::Xnnpack
 
 #endif  // IREE_SAMPLES_COMPILER_PLUGINS_XNNPACK_SAMPLE_TRANSFORMS_PASSES_H_

--- a/samples/compiler_plugins/xnnpack/src/xnnpack_sample/Transforms/Passes.td
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack_sample/Transforms/Passes.td
@@ -6,8 +6,8 @@
 
 include "mlir/Pass/PassBase.td"
 
-#ifndef IREE_XNNPACK_PASSES
-#define IREE_XNNPACK_PASSES
+#ifndef IREE_XNNPACK_TRANSFORMS_PASSES
+#define IREE_XNNPACK_TRANSFORMS_PASSES
 
 def LegalizeXnnpack : Pass<"iree-xnnpack-legalize", "mlir::ModuleOp"> {
   let summary = "Legalizes the xnnpack sample ops";
@@ -16,4 +16,4 @@ def LegalizeXnnpack : Pass<"iree-xnnpack-legalize", "mlir::ModuleOp"> {
   }];
 }
 
-#endif // IREE_XNNPACK_PASSES
+#endif // IREE_XNNPACK_TRANSFORMS_PASSES

--- a/samples/compiler_plugins/xnnpack/test/stablehlo_to_xnnpack.mlir
+++ b/samples/compiler_plugins/xnnpack/test/stablehlo_to_xnnpack.mlir
@@ -1,5 +1,9 @@
-func.func @batch_matrix_multiply(%a : tensor<1x100x200xi8>, %b : tensor<200x300xi8>) -> tensor<1x100x300xi32> {
+// RUN: iree-opt --iree-plugin=xnnpack_sample --iree-print-plugin-info --pass-pipeline='builtin.module(iree-stablehlo-to-xnnpack)' %s | FileCheck %s
+
+// CHECK-LABEL:   func.func @dot_general(
+// CHECK:           %{{.*}} = xnnpack.batch_matrix_multiply
+func.func @dot_general(%a : tensor<1x100x200xi8>, %b : tensor<200x300xi8>) -> tensor<1x100x300xi32> {
   %out = stablehlo.dot_general %a, %b, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<1x100x200xi8>, tensor<200x300xi8>) -> tensor<1x100x300xi32>
-  func.return %c : tensor<1x100x300xi32>
+  func.return %out : tensor<1x100x300xi32>
 }
 

--- a/samples/compiler_plugins/xnnpack/test/stablehlo_to_xnnpack.mlir
+++ b/samples/compiler_plugins/xnnpack/test/stablehlo_to_xnnpack.mlir
@@ -1,0 +1,5 @@
+func.func @batch_matrix_multiply(%a : tensor<1x100x200xi8>, %b : tensor<200x300xi8>) -> tensor<1x100x300xi32> {
+  %out = stablehlo.dot_general %a, %b, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<1x100x200xi8>, tensor<200x300xi8>) -> tensor<1x100x300xi32>
+  func.return %c : tensor<1x100x300xi32>
+}
+


### PR DESCRIPTION
This PR adds all the boilerplate for the pass `StablehloToXnnpack` in the `xnnpack` compiler plugin to convert `stablehlo` ops to the `xnnpack` dialect.

Currently the pass has a single pattern that replaces `stablehlo.dot_general` with `xnnpack.batch_matrix_multiply`. Follow up work includes:

- Add checks to the `stablehlo.dot_general` conversion to make sure we are only matching the matrix multiplications
- Add dimension unsqueezing for input tensors with rank < 3, to match the requirements of xnnpack.