### PR TITLE
Implement stablehlo dot general -> xnnpack batch matmul conversion + verifiers

### DIFF
--- a/samples/compiler_plugins/xnnpack/src/xnnpack/Conversion/StablehloToXnnpack.cpp
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack/Conversion/StablehloToXnnpack.cpp
@@ -4,6 +4,9 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <cstdint>
+
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "stablehlo/dialect/StablehloOps.h"
 #include "xnnpack/Conversion/Passes.h"
@@ -24,8 +27,52 @@ class ConvertDotGeneralOp
       ConversionPatternRewriter &rewriter) const override {
     Value lhs = adaptor.getLhs();
     Value rhs = adaptor.getRhs();
+    auto lhsType = lhs.getType().cast<RankedTensorType>();
+    auto rhsType = rhs.getType().cast<RankedTensorType>();
+
+    auto dotNumbers = op.getDotDimensionNumbers();
+    ArrayRef<int64_t> lhsContractingDims =
+        dotNumbers.getLhsContractingDimensions();
+    ArrayRef<int64_t> rhsContractingDims =
+        dotNumbers.getRhsContractingDimensions();
+    if (lhsContractingDims.size() != 1 || rhsContractingDims.size() != 1) {
+      return rewriter.notifyMatchFailure(
+          op, "expected at most one contracting dimension");
+    }
+    int64_t lhsContractingDim = lhsContractingDims.front();
+    int64_t rhsContractingDim = rhsContractingDims.front();
+    int64_t lhsBatchDimsCount = lhsType.getRank() - 2;
+    int64_t rhsBatchDimsCount = rhsType.getRank() - 2;
+    if (lhsContractingDim - lhsBatchDimsCount != 1 ||
+        rhsContractingDim - rhsBatchDimsCount != 0) {
+      return rewriter.notifyMatchFailure(op,
+                                         "not a batch matrix multiplication");
+    }
+
+    auto broadcastBatchDims = [&op, &rewriter](Value input,
+                                               int64_t batchDimCount) -> Value {
+      auto inputType = input.getType().cast<RankedTensorType>();
+      auto resultType = op.getType().cast<RankedTensorType>();
+      int64_t resultBatchDimCount = resultType.getRank() - 2;
+      ArrayRef<int64_t> inputShape(inputType.getShape());
+      SmallVector<int64_t> broadcastShape(resultType.getShape());
+      broadcastShape[resultBatchDimCount] = inputShape[batchDimCount];
+      broadcastShape[resultBatchDimCount + 1] = inputShape[batchDimCount + 1];
+      Type broadcastType =
+          RankedTensorType::get(broadcastShape, inputType.getElementType());
+
+      int64_t inputOutputDimDiff = resultBatchDimCount - batchDimCount;
+      DenseIntElementsAttr broadcastDims =
+          rewriter.getI64TensorAttr(llvm::to_vector(llvm::seq(
+              inputOutputDimDiff, inputType.getRank() + inputOutputDimDiff)));
+      return rewriter.create<mlir::stablehlo::BroadcastInDimOp>(
+          op.getLoc(), broadcastType, input, broadcastDims);
+    };
+
+    Value lhsBroadcast = broadcastBatchDims(lhs, lhsBatchDimsCount);
+    Value rhsBroadcast = broadcastBatchDims(rhs, rhsBatchDimsCount);
     rewriter.replaceOpWithNewOp<Xnnpack::BatchMatrixMultiplyOp>(
-        op, op.getType(), lhs, rhs);
+        op, op.getType(), lhsBroadcast, rhsBroadcast);
     return success();
   }
 };
@@ -42,7 +89,8 @@ class ConvertStablehloToXnnpackPass
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     ConversionTarget target(*context);
-    target.addLegalDialect<IREE::Xnnpack::XnnpackDialect>();
+    target.addLegalDialect<IREE::Xnnpack::XnnpackDialect,
+                           mlir::stablehlo::StablehloDialect>();
     TypeConverter typeConverter;
     typeConverter.addConversion([](Type type) { return type; });
     RewritePatternSet patterns(context);

--- a/samples/compiler_plugins/xnnpack/src/xnnpack/IR/XnnpackOps.cpp
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack/IR/XnnpackOps.cpp
@@ -6,8 +6,54 @@
 
 #include "xnnpack/IR/XnnpackOps.h"
 
+#include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpImplementation.h"
 
+namespace mlir::iree_compiler::IREE::Xnnpack {
+
+LogicalResult BatchMatrixMultiplyOp::verify() {
+  auto aType = getA().getType().cast<RankedTensorType>();
+  auto bType = getB().getType().cast<RankedTensorType>();
+  if (aType.getRank() < 3 || bType.getRank() < 3) {
+    return emitOpError()
+           << "expected operands to have rank >= 3, but got ranks: "
+           << aType.getRank() << " and " << bType.getRank();
+  }
+
+  if (aType.getRank() != bType.getRank()) {
+    return emitOpError()
+           << "expected operands to have the same rank, but got ranks: "
+           << aType.getRank() << " and " << bType.getRank();
+  }
+
+  ArrayRef<int64_t> aShape = aType.getShape();
+  ArrayRef<int64_t> bShape = bType.getShape();
+  for (auto [aDim, bDim] :
+       llvm::zip(aShape.drop_back(2), bShape.drop_back(2))) {
+    if (aDim != ShapedType::kDynamic && bDim != ShapedType::kDynamic &&
+        aDim != bDim) {
+      return emitOpError()
+             << "expected first N-2 dimensions to match, but dimension sizes "
+             << aDim << " != " << bDim;
+    }
+  }
+
+  int64_t aKDim = aShape.back();
+  int64_t bKDim = bShape.drop_back().back();
+  if (aKDim != ShapedType::kDynamic && bKDim != ShapedType::kDynamic &&
+      aKDim != bKDim) {
+    return emitOpError() << "expected reduction dimension to be the same in "
+                            "both operands, but got "
+                         << aKDim << " and " << bKDim;
+  }
+  return success();
+}
+}  // namespace mlir::iree_compiler::IREE::Xnnpack
+
+//===----------------------------------------------------------------------===//
+// TableGen definitions (intentionally last)
+//===----------------------------------------------------------------------===//
 // clang-format off
 #define GET_OP_CLASSES
 #include "xnnpack/IR/XnnpackOps.cpp.inc" // IWYU pragma: keep

--- a/samples/compiler_plugins/xnnpack/src/xnnpack/IR/XnnpackOps.td
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack/IR/XnnpackOps.td
@@ -38,6 +38,7 @@ def Xnnpack_BatchMatrixMultiplyOp : Xnnpack_Op<"batch_matrix_multiply", []> {
   let assemblyFormat = [{
     $a `,` $b attr-dict `:` functional-type(operands, results)
   }];
+  let hasVerifier = 1;
 }
 
 #endif

--- a/samples/compiler_plugins/xnnpack/test/stablehlo-to-xnnpack.mlir
+++ b/samples/compiler_plugins/xnnpack/test/stablehlo-to-xnnpack.mlir
@@ -1,7 +1,11 @@
 // RUN: iree-opt --iree-plugin=xnnpack --iree-print-plugin-info --pass-pipeline='builtin.module(iree-stablehlo-to-xnnpack)' %s | FileCheck %s
 
 // CHECK-LABEL:   func.func @dot_general(
-// CHECK:           %{{.*}} = xnnpack.batch_matrix_multiply
+// CHECK-SAME:                           %[[LHS:.*]]: tensor<1x100x200xi8>,
+// CHECK-SAME:                           %[[RHS:.*]]: tensor<200x300xi8>) -> tensor<1x100x300xi32> {
+// CHECK:           %[[LHS_BROADCAST:.*]] = stablehlo.broadcast_in_dim %[[LHS]], dims = [0, 1, 2] : (tensor<1x100x200xi8>) -> tensor<1x100x200xi8>
+// CHECK:           %[[RHS_BROADCAST:.*]] = stablehlo.broadcast_in_dim %[[RHS]], dims = [1, 2] : (tensor<200x300xi8>) -> tensor<1x200x300xi8>
+// CHECK:           %{{.*}} = xnnpack.batch_matrix_multiply %[[LHS_BROADCAST]], %[[RHS_BROADCAST]] : (tensor<1x100x200xi8>, tensor<1x200x300xi8>) -> tensor<1x100x300xi32>
 func.func @dot_general(%a : tensor<1x100x200xi8>, %b : tensor<200x300xi8>) -> tensor<1x100x300xi32> {
   %out = stablehlo.dot_general %a, %b, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<1x100x200xi8>, tensor<200x300xi8>) -> tensor<1x100x300xi32>
   func.return %out : tensor<1x100x300xi32>

--- a/samples/compiler_plugins/xnnpack/test/xnnpack-ops-invalid.mlir
+++ b/samples/compiler_plugins/xnnpack/test/xnnpack-ops-invalid.mlir
@@ -1,0 +1,31 @@
+// RUN: iree-opt --iree-plugin=xnnpack --verify-diagnostics --split-input-file %s
+
+func.func @batch_matrix_multiply$small_rank(%a : tensor<?x?x?xf32>, %b : tensor<?x?xf32>) -> tensor<?x?x?xf32> {
+  // expected-error@+1 {{expected operands to have rank >= 3}}
+  %c = xnnpack.batch_matrix_multiply %a, %b : (tensor<?x?x?xf32>, tensor<?x?xf32>) -> tensor<?x?x?xf32>
+  func.return %c : tensor<?x?x?xf32>
+}
+
+// -----
+
+func.func @batch_matrix_multiply$unequal_rank(%a : tensor<?x?x?xf32>, %b : tensor<?x?x?x?xf32>) -> tensor<?x?x?xf32> {
+  // expected-error@+1 {{expected operands to have the same rank}}
+  %c = xnnpack.batch_matrix_multiply %a, %b : (tensor<?x?x?xf32>, tensor<?x?x?x?xf32>) -> tensor<?x?x?xf32>
+  func.return %c : tensor<?x?x?xf32>
+}
+
+// -----
+
+func.func @batch_matrix_multiply$unequal_batch_dims(%a : tensor<3x?x?xf32>, %b : tensor<2x?x?xf32>) -> tensor<?x?x?xf32> {
+  // expected-error@+1 {{expected first N-2 dimensions to match}}
+  %c = xnnpack.batch_matrix_multiply %a, %b : (tensor<3x?x?xf32>, tensor<2x?x?xf32>) -> tensor<?x?x?xf32>
+  func.return %c : tensor<?x?x?xf32>
+}
+
+// -----
+
+func.func @batch_matrix_multiply$unequal_reduction_dim(%a : tensor<?x?x2xf32>, %b : tensor<?x3x?xf32>) -> tensor<?x?x?xf32> {
+  // expected-error@+1 {{expected reduction dimension to be the same}}
+  %c = xnnpack.batch_matrix_multiply %a, %b : (tensor<?x?x2xf32>, tensor<?x3x?xf32>) -> tensor<?x?x?xf32>
+  func.return %c : tensor<?x?x?xf32>
+}


### PR DESCRIPTION
This PR fully implements the conversion from `stablehlo.dot_general` to `xnnpack.batch_matrix_multiply`. Because `xnnpack.batch_matrix_multiply` does not support broadcasting, the pattern broadcasts the input tensors using stablehlo ops.

This PR also adds verifiers for the `xnnpack.batch_matrix_multiply` to make sure it matches the  input constraints specified in the [XNNPACK specification](https://github.com/google/XNNPACK/blob/5647d70d848dbe99d97edacac62501c97d16c6b5/include/xnnpack.h#L1449-L1468).