### PR TITLE
Add conversion from stablehlo.dot_general to xnnpack.fully_connected

### DIFF
--- a/samples/compiler_plugins/xnnpack/src/xnnpack/Conversion/StablehloToXnnpack.cpp
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack/Conversion/StablehloToXnnpack.cpp
@@ -6,7 +6,9 @@
 
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/SourceMgr.h"
-#include "mlir/Dialect/PDLInterp/IR/PDLInterp.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Verifier.h"
 #include "mlir/Parser/Parser.h"
 #include "mlir/Support/FileUtilities.h"
@@ -54,19 +56,155 @@ LogicalResult parsePatternFromFile(MLIRContext *context,
   return mlir::verify(*patternModule);
 }
 
+// If `val` is the result of a `stablehlo.convert`, get the unconverted value.
+static Value getUnconvertedValue(Value val) {
+  if (auto convert = val.getDefiningOp<mlir::stablehlo::ConvertOp>())
+    return convert.getOperand();
+  return val;
+}
+
+// If `val` is passed to a `stablehlo.convert`, get the converted value.
+static Value getConvertedValue(Value val) {
+  if (val.hasOneUse()) {
+    if (auto convert =
+            dyn_cast<stablehlo::ConvertOp>(*val.getUsers().begin())) {
+      return convert.getResult();
+    }
+  }
+  return val;
+}
+
 namespace {
-class ConvertDotGeneralOp
+// A fully connected layer is a sequence of stablehlo ops that behave as the
+// computation `matmul(input, weight.T()) + bias`.
+//
+// See `ConvertFullyConnectedLayer::getFullyConnectedInfo` for the constraints
+// on the fully connected layer pattern.
+//
+// TODO: Add support for `bias`
+class ConvertFullyConnectedLayer
     : public OpConversionPattern<mlir::stablehlo::DotGeneralOp> {
  public:
   using OpConversionPattern::OpConversionPattern;
+  static bool isFullyConnectedLayer(mlir::stablehlo::DotGeneralOp op) {
+    auto error = [](std::string _) { return failure(); };
+    return succeeded(
+        ConvertFullyConnectedLayer::getFullyConnectedInfo(op, error));
+  }
+
   LogicalResult matchAndRewrite(
       mlir::stablehlo::DotGeneralOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
-    Value lhs = adaptor.getLhs();
-    Value rhs = adaptor.getRhs();
-    rewriter.replaceOpWithNewOp<Xnnpack::BatchMatrixMultiplyOp>(
-        op, op.getType(), lhs, rhs);
+    auto error = [op, &rewriter](std::string msg) {
+      return rewriter.notifyMatchFailure(op, msg);
+    };
+    FailureOr<FullyConnectedInfo> maybeInfo = getFullyConnectedInfo(op, error);
+    if (failed(maybeInfo)) {
+      return error("unable to get fully connected info");
+    }
+    auto info = *maybeInfo;
+
+    auto inputType = info.input.getType().cast<RankedTensorType>();
+    auto weightType = info.weight.getType().cast<RankedTensorType>();
+    auto outputType = info.output.getType().cast<RankedTensorType>();
+    if (!inputType.getElementType().isInteger(8) ||
+        !weightType.getElementType().isInteger(4) ||
+        !outputType.getElementType().isF32()) {
+      return error(
+          "unimplemented: fully connected layer without i8 input, i4 weight, "
+          "or f32 output");
+    }
+
+    if (info.needsTranspose) {
+      int64_t weightRank = weightType.getRank();
+      SmallVector<int64_t> perm(llvm::to_vector(llvm::seq(weightRank)));
+      std::swap(perm[perm.size() - 1], perm[perm.size() - 2]);
+      DenseIntElementsAttr permAttr = rewriter.getI64TensorAttr(perm);
+      info.weight = rewriter.create<stablehlo::TransposeOp>(
+          op.getLoc(), info.weight, permAttr);
+    }
+
+    Operation *outputDefiningOp = info.output.getDefiningOp();
+    // If the matched `stablehlo.dot_general` op is not being replaced, it must
+    // be removed to avoid having the pattern applied again to it.
+    if (outputDefiningOp != op) rewriter.eraseOp(op);
+    rewriter.replaceOpWithNewOp<Xnnpack::FullyConnectedNcQd8F32Qc4wOp>(
+        outputDefiningOp, outputType, info.input, info.weight);
     return success();
+  }
+
+ private:
+  // Inputs and outputs of the matched fully connected layer pattern.
+  //
+  // The fully connected op performs a reduction along the last dimension of
+  // both the input and the weight. In other words:
+  //   `reduction_ik = input_ij * weight_kj`
+  // Therefore, if the matched `stablehlo.dot_general` op is performing
+  // the reduction along the first non-batch dimension of the weight
+  // (regular batch matrix multiplication), we need to transpose the last two
+  // dimensions of the weight tensor before computing the fully connected layer.
+  // The `needsTranspose` variable is true if such a tranpose of the weight is
+  // needed.
+  struct FullyConnectedInfo {
+    Value input;
+    Value weight;
+    Value output;
+    bool needsTranspose;  // Weight needs transpose before reduction `input_ij
+                          // weight_kj`
+  };
+
+  // Get the `stablehlo.dot_general`'s inputs before any casts and its output
+  // after any casts, and check if it matches the fully connected layer pattern.
+  static FailureOr<FullyConnectedInfo> getFullyConnectedInfo(
+      mlir::stablehlo::DotGeneralOp op,
+      llvm::function_ref<LogicalResult(std::string)> error) {
+    Value lhs = op.getLhs();
+    Value rhs = op.getRhs();
+    auto lhsType = lhs.getType().cast<RankedTensorType>();
+    auto rhsType = rhs.getType().cast<RankedTensorType>();
+
+    // The `stablehlo.dot_general` op has two attributes that encode the
+    // reduction of the two input tensors. The lists `lhsContractingDimensions`
+    // and `rhsContracingDimensions` represent the dimensions from both input
+    // tensors to "dot"-reduce. Since the fully connected layer is a reduction
+    // along a single dimension, here we only consider such cases.
+    auto dotNumbers = op.getDotDimensionNumbers();
+    ArrayRef<int64_t> lhsContractingDims =
+        dotNumbers.getLhsContractingDimensions();
+    ArrayRef<int64_t> rhsContractingDims =
+        dotNumbers.getRhsContractingDimensions();
+    if (lhsContractingDims.size() != 1 || rhsContractingDims.size() != 1) {
+      return error("expected at most one contracting dimension");
+    }
+    int64_t lhsContractingDim = lhsContractingDims.front();
+    int64_t rhsContractingDim = rhsContractingDims.front();
+    int64_t lhsBatchDimsCount = lhsType.getRank() - 2;
+    int64_t rhsBatchDimsCount = rhsType.getRank() - 2;
+    if (lhsContractingDim - lhsBatchDimsCount != 1 ||
+        (rhsContractingDim - rhsBatchDimsCount != 0 &&
+         rhsContractingDim - rhsBatchDimsCount != 1)) {
+      return error("not a fully connected pattern");
+    }
+
+    FullyConnectedInfo info;
+    info.input = getUnconvertedValue(lhs);
+    info.weight = getUnconvertedValue(rhs);
+    info.output = getConvertedValue(op.getResult());
+    info.needsTranspose = rhsContractingDim - rhsBatchDimsCount == 0;
+
+    auto inputType = info.input.getType().cast<RankedTensorType>();
+    auto weightType = info.weight.getType().cast<RankedTensorType>();
+    if (inputType.getRank() > 2) {
+      for (int64_t dimSize : inputType.getShape().drop_back(2)) {
+        if (dimSize != 1) {
+          return error(
+              "unimplemented: input with batch dimensions of size != 1");
+        }
+      }
+    }
+    if (weightType.getRank() != 2)
+      return error("unimplemented: weight with rank > 2");
+    return info;
   }
 };
 }  // namespace
@@ -82,10 +220,8 @@ class ConvertStablehloToXnnpackPass
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     ConversionTarget target(*context);
-    target.addLegalDialect<IREE::Xnnpack::XnnpackDialect>();
-    TypeConverter typeConverter;
-    typeConverter.addConversion([](Type type) { return type; });
-
+    target.addLegalDialect<IREE::Xnnpack::XnnpackDialect,
+                           mlir::stablehlo::StablehloDialect>();
     RewritePatternSet patterns(context);
 
     // Load patterns from a file if specified.
@@ -98,12 +234,14 @@ class ConvertStablehloToXnnpackPass
       patterns.add(std::move(pdlPattern));
     }
 
-    patterns.add<ConvertDotGeneralOp>(typeConverter, context);
-    target.addIllegalOp<stablehlo::DotGeneralOp>();
+    patterns.add<ConvertFullyConnectedLayer>(context);
+    target.addDynamicallyLegalOp<mlir::stablehlo::DotGeneralOp>(
+        std::not_fn(ConvertFullyConnectedLayer::isFullyConnectedLayer));
 
     if (failed(applyPartialConversion(getOperation(), target,
-                                      std::move(patterns))))
+                                      std::move(patterns)))) {
       return signalPassFailure();
+    }
   }
 };
 

--- a/samples/compiler_plugins/xnnpack/src/xnnpack/IR/XnnpackOps.td
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack/IR/XnnpackOps.td
@@ -40,4 +40,16 @@ def Xnnpack_BatchMatrixMultiplyOp : Xnnpack_Op<"batch_matrix_multiply", []> {
   }];
 }
 
+// TODO: Add bias and activation parameters
+def Xnnpack_FullyConnectedNcQd8F32Qc4wOp : Xnnpack_Op<"fully_connected_nc_qd8_f32_qc4w", []> {
+  let summary = "Fully connected layer with int8 input, int4 weights, and f32 output";
+  let arguments = (ins AnyRankedTensor:$a,
+                       AnyRankedTensor:$b);
+  let results = (outs AnyRankedTensor:$result);
+
+  let assemblyFormat = [{
+    $a `,` $b attr-dict `:` functional-type(operands, results)
+  }];
+}
+
 #endif

--- a/samples/compiler_plugins/xnnpack/test/stablehlo-to-xnnpack.mlir
+++ b/samples/compiler_plugins/xnnpack/test/stablehlo-to-xnnpack.mlir
@@ -1,9 +1,24 @@
 // RUN: iree-opt --iree-plugin=xnnpack --iree-print-plugin-info --pass-pipeline='builtin.module(iree-stablehlo-to-xnnpack)' %s | FileCheck %s
 
-// CHECK-LABEL:   func.func @dot_general(
-// CHECK:           %{{.*}} = xnnpack.batch_matrix_multiply
-func.func @dot_general(%a : tensor<1x100x200xi8>, %b : tensor<200x300xi8>) -> tensor<1x100x300xi32> {
-  %out = stablehlo.dot_general %a, %b, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<1x100x200xi8>, tensor<200x300xi8>) -> tensor<1x100x300xi32>
-  func.return %out : tensor<1x100x300xi32>
+// CHECK-LABEL:   func.func @fully_connected(
+// CHECK-SAME:                           %[[LHS:.*]]: tensor<1x100x200xi8>,
+// CHECK-SAME:                           %[[RHS:.*]]: tensor<300x200xi4>) -> tensor<1x100x300xf32> {
+// CHECK:           %{{.*}} = xnnpack.fully_connected_nc_qd8_f32_qc4w %[[LHS]], %[[RHS]] : (tensor<1x100x200xi8>, tensor<300x200xi4>) -> tensor<1x100x300xf32>
+func.func @fully_connected(%input : tensor<1x100x200xi8>, %weight : tensor<300x200xi4>) -> tensor<1x100x300xf32> {
+  %weight_cast = stablehlo.convert %weight : (tensor<300x200xi4>) -> tensor<300x200xi8>
+  %dot_general = stablehlo.dot_general %input, %weight_cast, contracting_dims = [2] x [1], precision = [DEFAULT, DEFAULT] : (tensor<1x100x200xi8>, tensor<300x200xi8>) -> tensor<1x100x300xi32>
+  %out = stablehlo.convert %dot_general : (tensor<1x100x300xi32>) -> tensor<1x100x300xf32>
+  return %out : tensor<1x100x300xf32>
 }
 
+// CHECK-LABEL:   func.func @fully_connected$transpose(
+// CHECK-SAME:                                     %[[LHS:.*]]: tensor<1x100x200xi8>,
+// CHECK-SAME:                                     %[[RHS:.*]]: tensor<200x300xi4>) -> tensor<1x100x300xf32> {
+// CHECK:           %[[TRANSPOSE:.*]] = stablehlo.transpose %[[RHS]], dims = [1, 0] : (tensor<200x300xi4>) -> tensor<300x200xi4>
+// CHECK:           %{{.*}} = xnnpack.fully_connected_nc_qd8_f32_qc4w %[[LHS]], %[[TRANSPOSE]] : (tensor<1x100x200xi8>, tensor<300x200xi4>) -> tensor<1x100x300xf32>
+func.func @fully_connected$transpose(%input : tensor<1x100x200xi8>, %weight : tensor<200x300xi4>) -> tensor<1x100x300xf32> {
+  %weight_cast = stablehlo.convert %weight : (tensor<200x300xi4>) -> tensor<200x300xi8>
+  %dot_general = stablehlo.dot_general %input, %weight_cast, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<1x100x200xi8>, tensor<200x300xi8>) -> tensor<1x100x300xi32>
+  %out = stablehlo.convert %dot_general : (tensor<1x100x300xi32>) -> tensor<1x100x300xf32>
+  return %out : tensor<1x100x300xf32>
+}


### PR DESCRIPTION
This PR adds a new op to the XNNPACK dialect: `fully_connected_nc_qd8_f32_qc4w`. This op corresponds to the [op with the same name](https://github.com/google/XNNPACK/blob/3bc4ef01bbdf488556c54584fc2419dd77c39c85/include/xnnpack.h#L3996) in `xnnpack.h`.

This PR also adds a pattern that identifies if `stablehlo.dot_general + cast ops` corresponds to a fully connected layer. If so, the pattern is replaced with the xnnpack operation.