### PR TITLE
Add e2e support for fully connected op

### DIFF
--- a/samples/compiler_plugins/xnnpack/src/xnnpack/Transforms/LegalizeXnnpack.cpp
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack/Transforms/LegalizeXnnpack.cpp
@@ -86,6 +86,20 @@ static FailureOr<SmallVector<SmallVector<Value>>> getInputOutputDims(
       return op->emitError("unimplemented: broadcasting");
     }
     dims.push_back({dims[0][0]});
+  } else if (auto fullyConnected = dyn_cast<FullyConnectedNcQd8F32Qc4wOp>(op)) {
+    auto typeA = fullyConnected.getA().getType().cast<RankedTensorType>();
+    auto typeB = fullyConnected.getB().getType().cast<RankedTensorType>();
+    if (typeA.getRank() != 3 && typeA.getShape()[0] != 1) {
+      return op->emitError(
+          "unimplemented: input with rank != 3 and first dimension size != 1");
+    }
+    if (typeB.getRank() != 2) {
+      return op->emitError("unimplemented: weight of rank != 2");
+    }
+    // Fully connected performs a reduction along the right-most dimension of
+    // the input and the weight.
+    // output shape = [input.dim(0), input.dim(1), weight.dim(0)]
+    dims.push_back({dims[0][0], dims[0][1], dims[1][0]});
   } else {
     llvm_unreachable("not an xnnpack op!");
   }

--- a/samples/compiler_plugins/xnnpack/test/batch-matrix-multiply-e2e.mlir
+++ b/samples/compiler_plugins/xnnpack/test/batch-matrix-multiply-e2e.mlir
@@ -6,12 +6,10 @@
 // RUN:     --function=main \
 // RUN:     --input=2x2x2xf32=2 \
 // RUN:     --input=2x2x2xf32=4 | \
-// llvm-lit does not like checking for '[['
-// RUN:     sed 's/\[/(/g' | \
 // RUN: FileCheck %s --check-prefix=CHECK-SYSTEM
 
 // CHECK-SYSTEM: EXEC @main
-// CHECK-SYSTEM: 2x2x2xf32=((16 16](16 16]]((16 16](16 16]]
+// CHECK-SYSTEM: 2x2x2xf32={{\[}}[16 16][16 16]]{{\[}}[16 16][16 16]]
 func.func @main(%a : tensor<?x2x2xf32>, %b : tensor<?x2x2xf32>) -> tensor<?x2x2xf32> {
   %c = xnnpack.batch_matrix_multiply %a, %b : (tensor<?x2x2xf32>, tensor<?x2x2xf32>) -> tensor<?x2x2xf32>
   func.return %c : tensor<?x2x2xf32>

--- a/samples/compiler_plugins/xnnpack/test/fully-connected-e2e.mlir
+++ b/samples/compiler_plugins/xnnpack/test/fully-connected-e2e.mlir
@@ -1,0 +1,24 @@
+// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --iree-plugin=xnnpack %s | \
+// RUN: iree-run-module \
+// RUN:     --device=local-sync \
+// RUN:     --executable_plugin=$IREE_BINARY_DIR/samples/custom_dispatch/xnnpack/plugin/system_plugin$IREE_DYLIB_EXT \
+// RUN:     --module=- \
+// RUN:     --function=main \
+// RUN:     --input=1x2x8xi8=1 \
+// RUN:     --input=4x8xi8=2 \
+// RUN:     --input=4x8xi8=8 | \
+// llvm-lit does not like checking for '[['
+// RUN:     sed 's/\[/(/g' | tee /tmp/dump.txt | \
+// RUN: FileCheck %s --check-prefix=CHECK-SYSTEM
+
+// CHECK-SYSTEM: EXEC @main
+// CHECK-SYSTEM: 1x2x4xf32=((16 16 16 16](16 16 16 16]]
+func.func @main(%a : tensor<1x2x8xi8>, %b : tensor<4x8xi8>, %shift : tensor<4x8xi8>) -> tensor<1x2x4xf32> {
+  // TODO: Avoid doing this shift.
+  // Currently, XNNPACK will shift the weight by -8, so here the
+  // weight is shifted in the other direction.
+  %b_shift = stablehlo.add %b, %shift : (tensor<4x8xi8>, tensor<4x8xi8>) -> tensor<4x8xi8>
+  %b_i4 = stablehlo.convert %b_shift : (tensor<4x8xi8>) -> tensor<4x8xi4>
+  %c = xnnpack.fully_connected_nc_qd8_f32_qc4w %a, %b_i4 : (tensor<1x2x8xi8>, tensor<4x8xi4>) -> tensor<1x2x4xf32>
+  func.return %c : tensor<1x2x4xf32>
+}

--- a/samples/compiler_plugins/xnnpack/test/fully-connected-e2e.mlir
+++ b/samples/compiler_plugins/xnnpack/test/fully-connected-e2e.mlir
@@ -7,18 +7,15 @@
 // RUN:     --input=1x2x8xi8=1 \
 // RUN:     --input=4x8xi8=2 \
 // RUN:     --input=4x8xi8=8 | \
-// llvm-lit does not like checking for '[['
-// RUN:     sed 's/\[/(/g' | tee /tmp/dump.txt | \
 // RUN: FileCheck %s --check-prefix=CHECK-SYSTEM
 
 // CHECK-SYSTEM: EXEC @main
-// CHECK-SYSTEM: 1x2x4xf32=((16 16 16 16](16 16 16 16]]
-func.func @main(%a : tensor<1x2x8xi8>, %b : tensor<4x8xi8>, %shift : tensor<4x8xi8>) -> tensor<1x2x4xf32> {
-  // TODO: Avoid doing this shift.
-  // Currently, XNNPACK will shift the weight by -8, so here the
-  // weight is shifted in the other direction.
-  %b_shift = stablehlo.add %b, %shift : (tensor<4x8xi8>, tensor<4x8xi8>) -> tensor<4x8xi8>
-  %b_i4 = stablehlo.convert %b_shift : (tensor<4x8xi8>) -> tensor<4x8xi4>
+// CHECK-SYSTEM: 1x2x4xf32={{\[}}[16 16 16 16][16 16 16 16]]
+func.func @main(%a : tensor<1x2x8xi8>, %b : tensor<4x8xi8>, %offset : tensor<4x8xi8>) -> tensor<1x2x4xf32> {
+  // TODO: Avoid doing this addition.
+  // Currently, XNNPACK will subtract the weight by 8, so here 8 is added to the weight.
+  %b_adjusted = stablehlo.add %b, %offset : (tensor<4x8xi8>, tensor<4x8xi8>) -> tensor<4x8xi8>
+  %b_i4 = stablehlo.convert %b_adjusted : (tensor<4x8xi8>) -> tensor<4x8xi4>
   %c = xnnpack.fully_connected_nc_qd8_f32_qc4w %a, %b_i4 : (tensor<1x2x8xi8>, tensor<4x8xi4>) -> tensor<1x2x4xf32>
   func.return %c : tensor<1x2x4xf32>
 }

--- a/samples/compiler_plugins/xnnpack/test/xnnpack-legalize.mlir
+++ b/samples/compiler_plugins/xnnpack/test/xnnpack-legalize.mlir
@@ -25,16 +25,36 @@
 // CHECK:           }
 // CHECK:           return %[[RESULT]] : tensor<?x?x?xf32>
 
+// CHECK-LABEL:   func.func private @xnnpack.fully_connected_nc_qd8_f32_qc4w(
+// CHECK-SAME:                                                               %[[A:.*]]: tensor<1x?x?xi8>,
+// CHECK-SAME:                                                               %[[B:.*]]: tensor<?x?xi4>) -> tensor<1x?x?xf32> {
+// CHECK:           %[[OUT:.*]] = tensor.empty(%[[A_DIM_1:.*]], %[[B_DIM_0:.*]]) : tensor<1x?x?xf32>
+// CHECK:           %[[RESULT:.*]] = flow.dispatch.region -> (tensor<1x?x?xf32>{%[[A_DIM_1]], %[[B_DIM_0]]}) {
+// CHECK:             %[[UKERNEL:.*]] = iree_codegen.ukernel.generic "xnnpack.fully_connected_nc_qd8_f32_qc4w_workgroup" ins(%[[A]], %[[B]] : tensor<1x?x?xi8>, tensor<?x?xi4>) outs(%[[OUT]] : tensor<1x?x?xf32>) (%[[A_DIM_0:.*]], %[[A_DIM_1]], %[[A_DIM_2:.*]], %[[B_DIM_0]], %[[B_DIM_1:.*]], %[[A_DIM_0]], %[[A_DIM_1]], %[[B_DIM_0]] : index, index, index, index, index, index, index, index) -> tensor<1x?x?xf32>
+// CHECK:             flow.return %[[UKERNEL]] : tensor<1x?x?xf32>
+// CHECK:           } count() -> (index, index, index) {
+// CHECK:             %[[ONE:.*]] = arith.constant 1 : index
+// CHECK:             flow.return %[[ONE]], %[[ONE]], %[[ONE]] : index, index, index
+// CHECK:           }
+// CHECK:           return %[[RESULT]] : tensor<1x?x?xf32>
+
 // CHECK-LABEL:   func.func @multiply2(
-// CHECK:           %[[VAL_2:.*]] = call @xnnpack.multiply2
+// CHECK:           %{{.*}} = call @xnnpack.multiply2
 func.func @multiply2(%a : tensor<?xf32>, %b : tensor<?xf32>) -> tensor<?xf32> {
   %c = xnnpack.multiply2 %a, %b : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
   func.return %c : tensor<?xf32>
 }
 
 // CHECK-LABEL:   func.func @batch_matrix_multiply(
-// CHECK:           %[[VAL_2:.*]] = call @xnnpack.batch_matrix_multiply
+// CHECK:           %{{.*}} = call @xnnpack.batch_matrix_multiply
 func.func @batch_matrix_multiply(%a : tensor<?x?x?xf32>, %b : tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
   %c = xnnpack.batch_matrix_multiply %a, %b : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
   func.return %c : tensor<?x?x?xf32>
+}
+
+// CHECK-LABEL:   func.func @fully_connected(
+// CHECK:           %{{.*}} = call @xnnpack.fully_connected_nc_qd8_f32_qc4w
+func.func @fully_connected(%a : tensor<1x?x?xi8>, %b : tensor<?x?xi4>) -> tensor<1x?x?xf32> {
+  %c = xnnpack.fully_connected_nc_qd8_f32_qc4w %a, %b : (tensor<1x?x?xi8>, tensor<?x?xi4>) -> tensor<1x?x?xf32>
+  func.return %c : tensor<1x?x?xf32>
 }


### PR DESCRIPTION
This PR adds the code to call into XNNPACK and execute the fully connected op. It uses the XNNPACK's operator API to avoid creating any subgraphs.