### PR TITLE
Add e2e support for specifying XNNPACK thread count

### DIFF
--- a/samples/compiler_plugins/xnnpack/src/PluginRegistration.cpp
+++ b/samples/compiler_plugins/xnnpack/src/PluginRegistration.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/PluginAPI/Client.h"
+#include "llvm/Support/CommandLine.h"
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/MLIRContext.h"
 #include "xnnpack/Conversion/Passes.h"
@@ -16,11 +17,19 @@ using namespace mlir::iree_compiler;
 
 namespace {
 
-struct MyOptions {
-  void bindOptions(OptionsBinder &binder) {}
+struct XnnpackOptions {
+  size_t xnnpackThreads = 1;
+
+  void bindOptions(OptionsBinder &binder) {
+    static llvm::cl::OptionCategory category("XNNPACK Plugin");
+    binder.opt<size_t>(
+        "xnnpack-threads", xnnpackThreads,
+        llvm::cl::desc("Number of threads in XNNPACK threadpool."),
+        llvm::cl::cat(category));
+  }
 };
 
-struct MySession : public PluginSession<MySession, MyOptions> {
+struct MySession : public PluginSession<MySession, XnnpackOptions> {
   static void registerPasses() {
     IREE::Xnnpack::registerXnnpackPluginTransformsPasses();
     IREE::Xnnpack::registerXnnpackPluginConversionPasses();
@@ -33,14 +42,17 @@ struct MySession : public PluginSession<MySession, MyOptions> {
   LogicalResult onActivate() override { return success(); }
 
   void extendPreprocessingPassPipeline(OpPassManager &pm) override {
+    IREE::Xnnpack::LegalizeXnnpackOptions legalizeXnnpackOptions;
+    legalizeXnnpackOptions.xnnpackThreads = options.xnnpackThreads;
+
     pm.addPass(IREE::Xnnpack::createConvertStablehloToXnnpackPass());
-    pm.addPass(IREE::Xnnpack::createLegalizeXnnpack());
+    pm.addPass(IREE::Xnnpack::createLegalizeXnnpack(legalizeXnnpackOptions));
   }
 };
 
 }  // namespace
 
-IREE_DEFINE_COMPILER_OPTION_FLAGS(MyOptions);
+IREE_DEFINE_COMPILER_OPTION_FLAGS(XnnpackOptions);
 
 extern "C" bool iree_register_compiler_plugin_xnnpack(
     mlir::iree_compiler::PluginRegistrar *registrar) {

--- a/samples/compiler_plugins/xnnpack/src/PluginRegistration.cpp
+++ b/samples/compiler_plugins/xnnpack/src/PluginRegistration.cpp
@@ -34,7 +34,7 @@ struct MySession : public PluginSession<MySession, MyOptions> {
 
   void extendPreprocessingPassPipeline(OpPassManager &pm) override {
     pm.addPass(IREE::Xnnpack::createConvertStablehloToXnnpackPass());
-    pm.addPass(IREE::Xnnpack::createLegalizeXnnpackPass());
+    pm.addPass(IREE::Xnnpack::createLegalizeXnnpack());
   }
 };
 

--- a/samples/compiler_plugins/xnnpack/src/xnnpack/Transforms/LegalizeXnnpack.cpp
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack/Transforms/LegalizeXnnpack.cpp
@@ -16,10 +16,10 @@
 #include "xnnpack/IR/XnnpackOps.h"
 #include "xnnpack/Transforms/Passes.h"
 
+namespace mlir::iree_compiler::IREE::Xnnpack {
 #define GEN_PASS_DEF_LEGALIZEXNNPACK
 #include "xnnpack/Transforms/Passes.h.inc"
 
-namespace mlir::iree_compiler::IREE::Xnnpack {
 namespace {
 static FailureOr<func::FuncOp> createFuncOp(
     RewriterBase &rewriter, Location loc, FunctionType type,
@@ -177,8 +177,13 @@ static FailureOr<func::FuncOp> createUKernelGeneric(
 }
 
 class LegalizeXnnpackPass
-    : public ::impl::LegalizeXnnpackBase<LegalizeXnnpackPass> {
+    : public impl::LegalizeXnnpackBase<LegalizeXnnpackPass> {
  public:
+  LegalizeXnnpackPass() = default;
+  LegalizeXnnpackPass(const LegalizeXnnpackPass &) {}
+  LegalizeXnnpackPass(const LegalizeXnnpackOptions &options) {
+    xnnpackThreads.setValue(options.xnnpackThreads);
+  }
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<tensor::TensorDialect, IREE::Flow::FlowDialect,
                     IREE::Codegen::IREECodegenDialect>();
@@ -210,9 +215,5 @@ class LegalizeXnnpackPass
 };
 
 }  // namespace
-
-std::unique_ptr<OperationPass<ModuleOp>> createLegalizeXnnpackPass() {
-  return std::make_unique<LegalizeXnnpackPass>();
-}
 
 }  // namespace mlir::iree_compiler::IREE::Xnnpack

--- a/samples/compiler_plugins/xnnpack/src/xnnpack/Transforms/Passes.h
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack/Transforms/Passes.h
@@ -12,8 +12,8 @@
 #include "mlir/Pass/PassManager.h"
 
 namespace mlir::iree_compiler::IREE::Xnnpack {
-
-std::unique_ptr<OperationPass<ModuleOp>> createLegalizeXnnpackPass();
+#define GEN_PASS_DECL
+#include "xnnpack/Transforms/Passes.h.inc"
 
 void registerXnnpackPluginTransformsPasses();
 

--- a/samples/compiler_plugins/xnnpack/src/xnnpack/Transforms/Passes.td
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack/Transforms/Passes.td
@@ -11,9 +11,10 @@ include "mlir/Pass/PassBase.td"
 
 def LegalizeXnnpack : Pass<"iree-xnnpack-legalize", "mlir::ModuleOp"> {
   let summary = "Legalizes the xnnpack ops";
-  let constructor = [{
-    ::mlir::iree_compiler::IREE::Xnnpack::createLegalizeXnnpackPass()
-  }];
+  let options = [
+    Option<"xnnpackThreads", "xnnpack-threads", "size_t", "/*default=*/1",
+           "Number of threads in XNNPACK threadpool.">,
+  ];
 }
 
 #endif // IREE_XNNPACK_TRANSFORMS_PASSES

--- a/samples/compiler_plugins/xnnpack/test/fully-connected-e2e.mlir
+++ b/samples/compiler_plugins/xnnpack/test/fully-connected-e2e.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --iree-plugin=xnnpack %s | \
+// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --iree-plugin=xnnpack %s --xnnpack-threads=2 | \
 // RUN: iree-run-module \
 // RUN:     --device=local-sync \
 // RUN:     --executable_plugin=$IREE_BINARY_DIR/samples/custom_dispatch/xnnpack/plugin/system_plugin$IREE_DYLIB_EXT \

--- a/samples/compiler_plugins/xnnpack/test/xnnpack-legalize.mlir
+++ b/samples/compiler_plugins/xnnpack/test/xnnpack-legalize.mlir
@@ -1,11 +1,12 @@
-// RUN: iree-opt --iree-plugin=xnnpack --iree-print-plugin-info --pass-pipeline='builtin.module(iree-xnnpack-legalize)' %s | FileCheck %s
+// RUN: iree-opt --iree-plugin=xnnpack --iree-print-plugin-info --pass-pipeline='builtin.module(iree-xnnpack-legalize{xnnpack-threads=7})' %s | FileCheck %s
 
 // CHECK-LABEL:   func.func private @xnnpack.multiply2(
 // CHECK-SAME:                                    %[[A:.*]]: tensor<?xf32>,
 // CHECK-SAME:                                    %[[B:.*]]: tensor<?xf32>) -> tensor<?xf32> {
 // CHECK:           %[[OUT:.*]] = tensor.empty(%[[A_DIM:.*]]) : tensor<?xf32>
 // CHECK:           %[[RESULT:.*]] = flow.dispatch.region -> (tensor<?xf32>{%[[A_DIM]]}) {
-// CHECK:             %[[UKERNEL:.*]] = iree_codegen.ukernel.generic "xnnpack.multiply2_workgroup" ins(%[[A]], %[[B]] : tensor<?xf32>, tensor<?xf32>) outs(%[[OUT]] : tensor<?xf32>) (%[[A_DIM]], %[[B_DIM:.*]], %[[A_DIM]] : index, index, index) -> tensor<?xf32>
+// CHECK:             %[[THREADS:.*]] = arith.constant 7
+// CHECK:             %[[UKERNEL:.*]] = iree_codegen.ukernel.generic "xnnpack.multiply2_workgroup" ins(%[[A]], %[[B]] : tensor<?xf32>, tensor<?xf32>) outs(%[[OUT]] : tensor<?xf32>) (%[[A_DIM]], %[[B_DIM:.*]], %[[A_DIM]], %[[THREADS]] : index, index, index, index) -> tensor<?xf32>
 // CHECK:             flow.return %[[UKERNEL]] : tensor<?xf32>
 // CHECK:           } count()
 // CHECK:             %[[ONE:.*]] = arith.constant 1 : index
@@ -17,7 +18,8 @@
 // CHECK-SAME:                                      %[[B:.*]]: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
 // CHECK:           %[[OUT:.*]] = tensor.empty(%[[A_DIM_0:.*]], %[[A_DIM_1:.*]], %[[B_DIM_2:.*]]) : tensor<?x?x?xf32>
 // CHECK:           %[[RESULT:.*]] = flow.dispatch.region -> (tensor<?x?x?xf32>{%[[A_DIM_0]], %[[A_DIM_1]], %[[B_DIM_2]]}) {
-// CHECK:             %[[UKERNEL:.*]] = iree_codegen.ukernel.generic "xnnpack.batch_matrix_multiply_workgroup" ins(%[[A]], %[[B]] : tensor<?x?x?xf32>, tensor<?x?x?xf32>) outs(%[[OUT]] : tensor<?x?x?xf32>) (%[[A_DIM_0]], %[[A_DIM_1]], %[[A_DIM_2:.*]], %[[B_DIM_0:.*]], %[[B_DIM_1:.*]], %[[B_DIM_2]], %[[A_DIM_0]], %[[A_DIM_1]], %[[B_DIM_2]] : index, index, index, index, index, index, index, index, index) -> tensor<?x?x?xf32>
+// CHECK:             %[[THREADS:.*]] = arith.constant 7
+// CHECK:             %[[UKERNEL:.*]] = iree_codegen.ukernel.generic "xnnpack.batch_matrix_multiply_workgroup" ins(%[[A]], %[[B]] : tensor<?x?x?xf32>, tensor<?x?x?xf32>) outs(%[[OUT]] : tensor<?x?x?xf32>) (%[[A_DIM_0]], %[[A_DIM_1]], %[[A_DIM_2:.*]], %[[B_DIM_0:.*]], %[[B_DIM_1:.*]], %[[B_DIM_2]], %[[A_DIM_0]], %[[A_DIM_1]], %[[B_DIM_2]], %[[THREADS]] : index, index, index, index, index, index, index, index, index, index) -> tensor<?x?x?xf32>
 // CHECK:             flow.return %[[UKERNEL]] : tensor<?x?x?xf32>
 // CHECK:           } count()
 // CHECK:             %[[ONE:.*]] = arith.constant 1 : index
@@ -30,7 +32,8 @@
 // CHECK-SAME:                                                               %[[B:.*]]: tensor<?x?xi4>) -> tensor<1x?x?xf32> {
 // CHECK:           %[[OUT:.*]] = tensor.empty(%[[A_DIM_1:.*]], %[[B_DIM_0:.*]]) : tensor<1x?x?xf32>
 // CHECK:           %[[RESULT:.*]] = flow.dispatch.region -> (tensor<1x?x?xf32>{%[[A_DIM_1]], %[[B_DIM_0]]}) {
-// CHECK:             %[[UKERNEL:.*]] = iree_codegen.ukernel.generic "xnnpack.fully_connected_nc_qd8_f32_qc4w_workgroup" ins(%[[A]], %[[B]] : tensor<1x?x?xi8>, tensor<?x?xi4>) outs(%[[OUT]] : tensor<1x?x?xf32>) (%[[A_DIM_0:.*]], %[[A_DIM_1]], %[[A_DIM_2:.*]], %[[B_DIM_0]], %[[B_DIM_1:.*]], %[[A_DIM_0]], %[[A_DIM_1]], %[[B_DIM_0]] : index, index, index, index, index, index, index, index) -> tensor<1x?x?xf32>
+// CHECK:             %[[THREADS:.*]] = arith.constant 7
+// CHECK:             %[[UKERNEL:.*]] = iree_codegen.ukernel.generic "xnnpack.fully_connected_nc_qd8_f32_qc4w_workgroup" ins(%[[A]], %[[B]] : tensor<1x?x?xi8>, tensor<?x?xi4>) outs(%[[OUT]] : tensor<1x?x?xf32>) (%[[A_DIM_0:.*]], %[[A_DIM_1]], %[[A_DIM_2:.*]], %[[B_DIM_0]], %[[B_DIM_1:.*]], %[[A_DIM_0]], %[[A_DIM_1]], %[[B_DIM_0]], %[[THREADS]] : index, index, index, index, index, index, index, index, index) -> tensor<1x?x?xf32>
 // CHECK:             flow.return %[[UKERNEL]] : tensor<1x?x?xf32>
 // CHECK:           } count() -> (index, index, index) {
 // CHECK:             %[[ONE:.*]] = arith.constant 1 : index

--- a/samples/custom_dispatch/xnnpack/plugin/system_ukernel.mlir
+++ b/samples/custom_dispatch/xnnpack/plugin/system_ukernel.mlir
@@ -34,7 +34,8 @@ func.func @main(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
   %dim_1 = tensor.dim %arg1, %c0_0 : tensor<?xf32>
   %0 = tensor.empty(%dim) : tensor<?xf32>
   %1 = flow.dispatch.region -> (tensor<?xf32>{%dim}) {
-    %2 = iree_codegen.ukernel.generic "xnnpack.multiply2_workgroup" ins(%arg0, %arg1 : tensor<?xf32>, tensor<?xf32>) outs(%0 : tensor<?xf32>) (%dim, %dim_1, %dim : index, index, index) -> tensor<?xf32>
+    %threads = arith.constant 1 : index
+    %2 = iree_codegen.ukernel.generic "xnnpack.multiply2_workgroup" ins(%arg0, %arg1 : tensor<?xf32>, tensor<?xf32>) outs(%0 : tensor<?xf32>) (%dim, %dim_1, %dim, %threads : index, index, index, index) -> tensor<?xf32>
     flow.return %2 : tensor<?xf32>
   } count() -> (index, index, index) {
     %c1 = arith.constant 1 : index


### PR DESCRIPTION
This PR adds the `iree-compile` options `xnnpack-threads` that specifies the number of threads in the XNNPACK threadpool. The option is currently plumbed through to each xnnpack dialect op after legalization. In order to achieve the use of flags, this PR also makes some minor changes to the pass autogeneration of `legalize-xnnpack`.

Current limitation:
- The threadpool is created every time an op is called. This can be fixed by
  - storing the threadpool after it gets created for the first time in the `void* context` variable that gets passed to every executable plugin function
  - creating xnnpack dialect ops for creating the threadpool, which can then be inserted as part of the MLIR