### PR TITLE
Add e2e support for specifying thread count at runtime

### DIFF
--- a/runtime/src/iree/hal/local/plugins/registration/init.c
+++ b/runtime/src/iree/hal/local/plugins/registration/init.c
@@ -7,6 +7,7 @@
 #include "iree/hal/local/plugins/registration/init.h"
 
 #include "iree/base/internal/flags.h"
+#include "iree/base/string_view.h"
 
 #if defined(IREE_HAVE_HAL_EXECUTABLE_SYSTEM_LIBRARY_PLUGIN)
 #include "iree/hal/local/plugins/system_library_plugin.h"
@@ -15,6 +16,13 @@
 #if defined(IREE_HAVE_HAL_EXECUTABLE_EMBEDDED_ELF_PLUGIN)
 #include "iree/hal/local/plugins/embedded_elf_plugin.h"
 #endif  // IREE_HAVE_HAL_EXECUTABLE_EMBEDDED_ELF_PLUGIN
+
+// TODO: figure out a better place for this
+// Also, having the type be `string` is a bit awkward
+IREE_FLAG(
+    string, xnnpack_thread_count, /*default=*/"0",
+    "Number of threads to use in XNNPACK's threadpool.\n"
+    "A value of 0 defaults to the number of logical processors in the system.");
 
 IREE_FLAG_LIST(
     string, executable_plugin,
@@ -81,8 +89,10 @@ iree_status_t iree_hal_register_executable_plugin_from_spec(
     iree_allocator_t host_allocator) {
   // TODO(benvanik): support parameterization via ?query or something.
   iree_string_view_t path = spec;
-  iree_host_size_t param_count = 0;
+  iree_host_size_t param_count = 1;
   iree_string_pair_t params[1];
+  params[0] =
+      iree_make_cstring_pair("xnnpack-thread-count", FLAG_xnnpack_thread_count);
 
   // NOTE: it's possible for no plugins to be enabled.
   (void)path;

--- a/samples/compiler_plugins/xnnpack/src/PluginRegistration.cpp
+++ b/samples/compiler_plugins/xnnpack/src/PluginRegistration.cpp
@@ -5,7 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/PluginAPI/Client.h"
-#include "llvm/Support/CommandLine.h"
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/MLIRContext.h"
 #include "xnnpack/Conversion/Passes.h"
@@ -18,15 +17,7 @@ using namespace mlir::iree_compiler;
 namespace {
 
 struct XnnpackOptions {
-  size_t xnnpackThreads = 1;
-
-  void bindOptions(OptionsBinder &binder) {
-    static llvm::cl::OptionCategory category("XNNPACK Plugin");
-    binder.opt<size_t>(
-        "xnnpack-threads", xnnpackThreads,
-        llvm::cl::desc("Number of threads in XNNPACK threadpool."),
-        llvm::cl::cat(category));
-  }
+  void bindOptions(OptionsBinder &binder) {}
 };
 
 struct XnnpackSession : public PluginSession<XnnpackSession, XnnpackOptions> {
@@ -42,11 +33,8 @@ struct XnnpackSession : public PluginSession<XnnpackSession, XnnpackOptions> {
   LogicalResult onActivate() override { return success(); }
 
   void extendPreprocessingPassPipeline(OpPassManager &pm) override {
-    IREE::Xnnpack::LegalizeXnnpackOptions legalizeXnnpackOptions;
-    legalizeXnnpackOptions.xnnpackThreads = options.xnnpackThreads;
-
     pm.addPass(IREE::Xnnpack::createConvertStablehloToXnnpack());
-    pm.addPass(IREE::Xnnpack::createLegalizeXnnpack(legalizeXnnpackOptions));
+    pm.addPass(IREE::Xnnpack::createLegalizeXnnpack());
   }
 };
 

--- a/samples/compiler_plugins/xnnpack/src/xnnpack/Transforms/Passes.td
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack/Transforms/Passes.td
@@ -11,10 +11,6 @@ include "mlir/Pass/PassBase.td"
 
 def LegalizeXnnpack : Pass<"iree-xnnpack-legalize", "mlir::ModuleOp"> {
   let summary = "Legalizes the xnnpack ops";
-  let options = [
-    Option<"xnnpackThreads", "xnnpack-threads", "size_t", "/*default=*/1",
-           "Number of threads in XNNPACK threadpool.">,
-  ];
 }
 
 #endif // IREE_XNNPACK_TRANSFORMS_PASSES

--- a/samples/compiler_plugins/xnnpack/test/batch-matrix-multiply-e2e.mlir
+++ b/samples/compiler_plugins/xnnpack/test/batch-matrix-multiply-e2e.mlir
@@ -5,7 +5,8 @@
 // RUN:     --module=- \
 // RUN:     --function=main \
 // RUN:     --input=2x2x2xf32=2 \
-// RUN:     --input=2x2x2xf32=4 | \
+// RUN:     --input=2x2x2xf32=4 \
+// RUN:     --xnnpack_thread_count=1 |\
 // RUN: FileCheck %s --check-prefix=CHECK-SYSTEM
 
 // CHECK-SYSTEM: EXEC @main

--- a/samples/compiler_plugins/xnnpack/test/fully-connected-e2e.mlir
+++ b/samples/compiler_plugins/xnnpack/test/fully-connected-e2e.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --iree-plugin=xnnpack %s --xnnpack-threads=2 | \
+// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --iree-plugin=xnnpack %s | \
 // RUN: iree-run-module \
 // RUN:     --device=local-sync \
 // RUN:     --executable_plugin=$IREE_BINARY_DIR/samples/custom_dispatch/xnnpack/plugin/system_plugin$IREE_DYLIB_EXT \

--- a/samples/compiler_plugins/xnnpack/test/fully-connected-e2e.mlir
+++ b/samples/compiler_plugins/xnnpack/test/fully-connected-e2e.mlir
@@ -6,7 +6,7 @@
 // RUN:     --function=main \
 // RUN:     --input=1x2x8xi8=1 \
 // RUN:     --input=4x8xi8=2 \
-// RUN:     --input=4x8xi8=8 | \
+// RUN:     --input=4x8xi8=8 --xnnpack_thread_count=2 | \
 // RUN: FileCheck %s --check-prefix=CHECK-SYSTEM
 
 // CHECK-SYSTEM: EXEC @main

--- a/samples/compiler_plugins/xnnpack/test/mul2-1d-e2e.mlir
+++ b/samples/compiler_plugins/xnnpack/test/mul2-1d-e2e.mlir
@@ -5,7 +5,8 @@
 // RUN:     --module=- \
 // RUN:     --function=main \
 // RUN:     --input=8xf32=2 \
-// RUN:     --input=8xf32=4 | \
+// RUN:     --input=8xf32=4 \
+// RUN:     --xnnpack_thread_count=1 |\
 // RUN: FileCheck %s --check-prefix=CHECK-SYSTEM
 
 // CHECK-SYSTEM: EXEC @main

--- a/samples/compiler_plugins/xnnpack/test/xnnpack-legalize.mlir
+++ b/samples/compiler_plugins/xnnpack/test/xnnpack-legalize.mlir
@@ -1,12 +1,11 @@
-// RUN: iree-opt --iree-plugin=xnnpack --iree-print-plugin-info --pass-pipeline='builtin.module(iree-xnnpack-legalize{xnnpack-threads=7})' %s | FileCheck %s
+// RUN: iree-opt --iree-plugin=xnnpack --iree-print-plugin-info --pass-pipeline='builtin.module(iree-xnnpack-legalize)' %s | FileCheck %s
 
 // CHECK-LABEL:   func.func private @xnnpack.multiply2(
 // CHECK-SAME:                                    %[[A:.*]]: tensor<?xf32>,
 // CHECK-SAME:                                    %[[B:.*]]: tensor<?xf32>) -> tensor<?xf32> {
 // CHECK:           %[[OUT:.*]] = tensor.empty(%[[A_DIM:.*]]) : tensor<?xf32>
 // CHECK:           %[[RESULT:.*]] = flow.dispatch.region -> (tensor<?xf32>{%[[A_DIM]]}) {
-// CHECK:             %[[THREADS:.*]] = arith.constant 7
-// CHECK:             %[[UKERNEL:.*]] = iree_codegen.ukernel.generic "xnnpack.multiply2_workgroup" ins(%[[A]], %[[B]] : tensor<?xf32>, tensor<?xf32>) outs(%[[OUT]] : tensor<?xf32>) (%[[A_DIM]], %[[B_DIM:.*]], %[[A_DIM]], %[[THREADS]] : index, index, index, index) -> tensor<?xf32>
+// CHECK:             %[[UKERNEL:.*]] = iree_codegen.ukernel.generic "xnnpack.multiply2_workgroup" ins(%[[A]], %[[B]] : tensor<?xf32>, tensor<?xf32>) outs(%[[OUT]] : tensor<?xf32>) (%[[A_DIM]], %[[B_DIM:.*]], %[[A_DIM]] : index, index, index) -> tensor<?xf32>
 // CHECK:             flow.return %[[UKERNEL]] : tensor<?xf32>
 // CHECK:           } count()
 // CHECK:             %[[ONE:.*]] = arith.constant 1 : index
@@ -18,8 +17,7 @@
 // CHECK-SAME:                                      %[[B:.*]]: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
 // CHECK:           %[[OUT:.*]] = tensor.empty(%[[A_DIM_0:.*]], %[[A_DIM_1:.*]], %[[B_DIM_2:.*]]) : tensor<?x?x?xf32>
 // CHECK:           %[[RESULT:.*]] = flow.dispatch.region -> (tensor<?x?x?xf32>{%[[A_DIM_0]], %[[A_DIM_1]], %[[B_DIM_2]]}) {
-// CHECK:             %[[THREADS:.*]] = arith.constant 7
-// CHECK:             %[[UKERNEL:.*]] = iree_codegen.ukernel.generic "xnnpack.batch_matrix_multiply_workgroup" ins(%[[A]], %[[B]] : tensor<?x?x?xf32>, tensor<?x?x?xf32>) outs(%[[OUT]] : tensor<?x?x?xf32>) (%[[A_DIM_0]], %[[A_DIM_1]], %[[A_DIM_2:.*]], %[[B_DIM_0:.*]], %[[B_DIM_1:.*]], %[[B_DIM_2]], %[[A_DIM_0]], %[[A_DIM_1]], %[[B_DIM_2]], %[[THREADS]] : index, index, index, index, index, index, index, index, index, index) -> tensor<?x?x?xf32>
+// CHECK:             %[[UKERNEL:.*]] = iree_codegen.ukernel.generic "xnnpack.batch_matrix_multiply_workgroup" ins(%[[A]], %[[B]] : tensor<?x?x?xf32>, tensor<?x?x?xf32>) outs(%[[OUT]] : tensor<?x?x?xf32>) (%[[A_DIM_0]], %[[A_DIM_1]], %[[A_DIM_2:.*]], %[[B_DIM_0:.*]], %[[B_DIM_1:.*]], %[[B_DIM_2]], %[[A_DIM_0]], %[[A_DIM_1]], %[[B_DIM_2]] : index, index, index, index, index, index, index, index, index) -> tensor<?x?x?xf32>
 // CHECK:             flow.return %[[UKERNEL]] : tensor<?x?x?xf32>
 // CHECK:           } count()
 // CHECK:             %[[ONE:.*]] = arith.constant 1 : index
@@ -32,8 +30,7 @@
 // CHECK-SAME:                                                               %[[B:.*]]: tensor<?x?xi4>) -> tensor<1x?x?xf32> {
 // CHECK:           %[[OUT:.*]] = tensor.empty(%[[A_DIM_1:.*]], %[[B_DIM_0:.*]]) : tensor<1x?x?xf32>
 // CHECK:           %[[RESULT:.*]] = flow.dispatch.region -> (tensor<1x?x?xf32>{%[[A_DIM_1]], %[[B_DIM_0]]}) {
-// CHECK:             %[[THREADS:.*]] = arith.constant 7
-// CHECK:             %[[UKERNEL:.*]] = iree_codegen.ukernel.generic "xnnpack.fully_connected_nc_qd8_f32_qc4w_workgroup" ins(%[[A]], %[[B]] : tensor<1x?x?xi8>, tensor<?x?xi4>) outs(%[[OUT]] : tensor<1x?x?xf32>) (%[[A_DIM_0:.*]], %[[A_DIM_1]], %[[A_DIM_2:.*]], %[[B_DIM_0]], %[[B_DIM_1:.*]], %[[A_DIM_0]], %[[A_DIM_1]], %[[B_DIM_0]], %[[THREADS]] : index, index, index, index, index, index, index, index, index) -> tensor<1x?x?xf32>
+// CHECK:             %[[UKERNEL:.*]] = iree_codegen.ukernel.generic "xnnpack.fully_connected_nc_qd8_f32_qc4w_workgroup" ins(%[[A]], %[[B]] : tensor<1x?x?xi8>, tensor<?x?xi4>) outs(%[[OUT]] : tensor<1x?x?xf32>) (%[[A_DIM_0:.*]], %[[A_DIM_1]], %[[A_DIM_2:.*]], %[[B_DIM_0]], %[[B_DIM_1:.*]], %[[A_DIM_0]], %[[A_DIM_1]], %[[B_DIM_0]] : index, index, index, index, index, index, index, index) -> tensor<1x?x?xf32>
 // CHECK:             flow.return %[[UKERNEL]] : tensor<1x?x?xf32>
 // CHECK:           } count() -> (index, index, index) {
 // CHECK:             %[[ONE:.*]] = arith.constant 1 : index

--- a/samples/custom_dispatch/xnnpack/plugin/system_plugin.c
+++ b/samples/custom_dispatch/xnnpack/plugin/system_plugin.c
@@ -72,7 +72,6 @@ static int fully_connected_nc_qd8_f32_qc4w_workgroup(void* params_ptr,
     size_t binding2_size0;
     size_t binding2_size1;
     size_t binding2_size2;
-    size_t threads;
   } params_t;
   const params_t* params = (const params_t*)params_ptr;
 
@@ -158,10 +157,10 @@ static int multiply2_1d_workgroup(void* params_ptr, void* context,
     size_t binding0_size;
     size_t binding1_size;
     size_t binding2_size;
-    size_t threads;
   } params_t;
   const params_t* params = (const params_t*)params_ptr;
-  assert(params->threads == 1 && "unimplemented: threadpool support");
+  assert(pthreadpool_get_threads_count(plugin->threadpool) == 1 &&
+         "unimplemented: threadpool support");
 
   enum xnn_status status;
   xnn_subgraph_t subgraph = NULL;
@@ -264,10 +263,10 @@ static int batch_matrix_multiply_workgroup(void* params_ptr, void* context,
     size_t binding2_size0;
     size_t binding2_size1;
     size_t binding2_size2;
-    size_t threads;
   } params_t;
   const params_t* params = (const params_t*)params_ptr;
-  assert(params->threads == 1 && "unimplemented: threadpool support");
+  assert(pthreadpool_get_threads_count(plugin->threadpool) == 1 &&
+         "unimplemented: threadpool support");
 
   enum xnn_status status;
   xnn_subgraph_t subgraph = NULL;

--- a/samples/custom_dispatch/xnnpack/plugin/system_ukernel.mlir
+++ b/samples/custom_dispatch/xnnpack/plugin/system_ukernel.mlir
@@ -11,7 +11,8 @@
 // RUN:     --function="main" \
 // RUN:     --module=- \
 // RUN:     --input=8xf32=2 \
-// RUN:     --input=8xf32=4 | \
+// RUN:     --input=8xf32=4 \
+// RUN:     --xnnpack_thread_count=1 |\
 // RUN: FileCheck %s --check-prefix=CHECK-SYSTEM
 
 // CHECK-SYSTEM: EXEC @main

--- a/samples/custom_dispatch/xnnpack/plugin/system_ukernel.mlir
+++ b/samples/custom_dispatch/xnnpack/plugin/system_ukernel.mlir
@@ -34,8 +34,7 @@ func.func @main(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
   %dim_1 = tensor.dim %arg1, %c0_0 : tensor<?xf32>
   %0 = tensor.empty(%dim) : tensor<?xf32>
   %1 = flow.dispatch.region -> (tensor<?xf32>{%dim}) {
-    %threads = arith.constant 1 : index
-    %2 = iree_codegen.ukernel.generic "xnnpack.multiply2_workgroup" ins(%arg0, %arg1 : tensor<?xf32>, tensor<?xf32>) outs(%0 : tensor<?xf32>) (%dim, %dim_1, %dim, %threads : index, index, index, index) -> tensor<?xf32>
+    %2 = iree_codegen.ukernel.generic "xnnpack.multiply2_workgroup" ins(%arg0, %arg1 : tensor<?xf32>, tensor<?xf32>) outs(%0 : tensor<?xf32>) (%dim, %dim_1, %dim : index, index, index) -> tensor<?xf32>
     flow.return %2 : tensor<?xf32>
   } count() -> (index, index, index) {
     %c1 = arith.constant 1 : index


### PR DESCRIPTION
This PR add the ability to specify the number of threads for XNNPACK to use in it's threadpool. The threadpool is created when the XNNPACK executable plugin is loaded, and it is shared by all the XNNPACK plugin dispatches.

This PR also moves the initialization/de-initialization code of XNNPACK to the load and unload functions of the executable plugin.

Lastly, the compile time flag for specifying thread count is removed.

**Note:** There is no nice way, AFAICT, of adding flags to `iree-run-module`. The way the flag support is achieved here is by directly modifying the `iree/hal` code. Future work will include finding a better solution to this.