### PR TITLE
Use the greedy pattern matcher and add a PDLL pattern for fully connected.

### DIFF
--- a/samples/compiler_plugins/xnnpack/BUILD.bazel
+++ b/samples/compiler_plugins/xnnpack/BUILD.bazel
@@ -137,6 +137,7 @@ cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:PDLInterpDialect",
         "@llvm-project//mlir:Parser",
+        "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:Transforms",
         "@stablehlo//:stablehlo_ops",

--- a/samples/compiler_plugins/xnnpack/CMakeLists.txt
+++ b/samples/compiler_plugins/xnnpack/CMakeLists.txt
@@ -108,6 +108,7 @@ iree_cc_library(
     MLIRIR
     MLIRPDLInterpDialect
     MLIRParser
+    MLIRPass
     MLIRSupport
     MLIRTransforms
     StablehloOps

--- a/samples/compiler_plugins/xnnpack/src/xnnpack/Conversion/StablehloToXnnpack.cpp
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack/Conversion/StablehloToXnnpack.cpp
@@ -148,12 +148,6 @@ class ConvertFullyConnectedLayer
  public:
   using OpRewritePattern<mlir::stablehlo::ConvertOp>::OpRewritePattern;
 
-  static bool isFullyConnectedLayer(mlir::stablehlo::DotGeneralOp op) {
-    auto error = [](std::string _) { return failure(); };
-    return succeeded(
-        ConvertFullyConnectedLayer::getFullyConnectedInfo(op, error));
-  }
-
   LogicalResult matchAndRewrite(mlir::stablehlo::ConvertOp op,
                                 PatternRewriter &rewriter) const override {
     auto error = [op, &rewriter](std::string msg) {

--- a/samples/compiler_plugins/xnnpack/test/patterns.pdll
+++ b/samples/compiler_plugins/xnnpack/test/patterns.pdll
@@ -1,3 +1,25 @@
+
 Pattern => replace op<stablehlo.multiply>(operands: ValueRange) with
                    op<xnnpack.multiply2>(operands);
 
+// External constraints for type checking
+Constraint CheckI4RankedTensorType(value: Value);
+Constraint CheckI8RankedTensorType(value: Value);
+Constraint CheckI32RankedTensorType(value: Value);
+Constraint CheckF32RankedTensorType(value: Value);
+
+Pattern {
+  let i8_input : Value;  // lhs
+  let i4_input : Value;  // rhs
+  let cvt_i4_i8 = op<stablehlo.convert>(i4_input);       // rhs: i4 -> i8
+  let dot_general = op<stablehlo.dot_general>(i8_input, cvt_i4_i8);
+  let cvt_i32_f32 = op<stablehlo.convert>(dot_general);  // result: i32 -> f32
+
+  CheckI4RankedTensorType(i4_input);
+  CheckI8RankedTensorType(cvt_i4_i8);
+  CheckI8RankedTensorType(i8_input);
+  CheckI32RankedTensorType(dot_general);
+  CheckF32RankedTensorType(cvt_i32_f32);
+
+  replace cvt_i32_f32 with op<xnnpack.fully_connected_nc_qd8_f32_qc4w>(i8_input, i4_input);
+}

--- a/samples/compiler_plugins/xnnpack/test/patterns.pdll
+++ b/samples/compiler_plugins/xnnpack/test/patterns.pdll
@@ -7,6 +7,7 @@ Constraint CheckI4RankedTensorType(value: Value);
 Constraint CheckI8RankedTensorType(value: Value);
 Constraint CheckI32RankedTensorType(value: Value);
 Constraint CheckF32RankedTensorType(value: Value);
+Constraint CheckInnermostReduction(value: Value);
 
 Pattern {
   let i8_input : Value;  // lhs
@@ -19,6 +20,7 @@ Pattern {
   CheckI8RankedTensorType(cvt_i4_i8);
   CheckI8RankedTensorType(i8_input);
   CheckI32RankedTensorType(dot_general);
+  CheckInnermostReduction(dot_general);
   CheckF32RankedTensorType(cvt_i32_f32);
 
   replace cvt_i32_f32 with op<xnnpack.fully_connected_nc_qd8_f32_qc4w>(i8_input, i4_input);

--- a/samples/compiler_plugins/xnnpack/test/stablehlo-to-xnnpack-using-pdll.mlir
+++ b/samples/compiler_plugins/xnnpack/test/stablehlo-to-xnnpack-using-pdll.mlir
@@ -12,3 +12,13 @@ func.func @multiply(%a : tensor<100x200xi8>, %b : tensor<100x200xi8>) -> tensor<
   func.return %out : tensor<100x200xi8>
 }
 
+// CHECK-LABEL:   func.func @fully_connected(
+// CHECK-SAME:                           %[[LHS:.*]]: tensor<1x100x200xi8>,
+// CHECK-SAME:                           %[[RHS:.*]]: tensor<300x200xi4>) -> tensor<1x100x300xf32> {
+// CHECK:           %{{.*}} = xnnpack.fully_connected_nc_qd8_f32_qc4w %[[LHS]], %[[RHS]] : (tensor<1x100x200xi8>, tensor<300x200xi4>) -> tensor<1x100x300xf32>
+func.func @fully_connected(%input : tensor<1x100x200xi8>, %weight : tensor<300x200xi4>) -> tensor<1x100x300xf32> {
+  %weight_cast = stablehlo.convert %weight : (tensor<300x200xi4>) -> tensor<300x200xi8>
+  %dot_general = stablehlo.dot_general %input, %weight_cast, contracting_dims = [2] x [1], precision = [DEFAULT, DEFAULT] : (tensor<1x100x200xi8>, tensor<300x200xi8>) -> tensor<1x100x300xi32>
+  %out = stablehlo.convert %dot_general : (tensor<1x100x300xi32>) -> tensor<1x100x300xf32>
+  return %out : tensor<1x100x300xf32>
+}


### PR DESCRIPTION
1. Use the greedy pattern rewriter
    
    The greedy pattern rewriter fits better for the purpose since we are not
    doing the whole dialect lowering into a new dialect.

2. Match a fully connected pattern with PDLL
    
    There are C++ constraints for type checking, but still PDLL is much conciser
    than the C++ pattern matching.
    
    We still need to do the transpose handling to fully replace the C++ pattern code.
    
    Note that without the pattern file, the normal C++ pattern matcher will be used,
    so we don't need another flag to tell which pattern matcher to use.

