### PR TITLE
Move stablehlo-to-xnnpack to input conversion preprocessing pipeline

### DIFF
--- a/samples/compiler_plugins/xnnpack/src/PluginRegistration.cpp
+++ b/samples/compiler_plugins/xnnpack/src/PluginRegistration.cpp
@@ -32,8 +32,12 @@ struct XnnpackSession : public PluginSession<XnnpackSession, XnnpackOptions> {
 
   LogicalResult onActivate() override { return success(); }
 
-  void extendPreprocessingPassPipeline(OpPassManager &pm) override {
+  void extendInputConversionPreprocessingPassPipeline(
+      OpPassManager &pm, InputDialectOptions::Type inputType) override {
     pm.addPass(IREE::Xnnpack::createConvertStablehloToXnnpack());
+  }
+
+  void extendPreprocessingPassPipeline(OpPassManager &pm) override {
     pm.addPass(IREE::Xnnpack::createLegalizeXnnpack());
   }
 };


### PR DESCRIPTION
IREE converts StableHLO to Linalg before calling the preprocessing pass pipeline in the compiler plugins, preventing the `stablehlo-to-xnnpack` pass from performing the rewrite at the right time.

This commit moves the `stablehlo-to-xnnpack` pass to the input conversion preprocessing pipeline to rewrite the graph before any other input conversions are performed.