### PR TITLE
Avoid crash when stablehlo.convert's operand has no defining op

### DIFF
--- a/samples/compiler_plugins/xnnpack/src/xnnpack/Conversion/StablehloToXnnpack.cpp
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack/Conversion/StablehloToXnnpack.cpp
@@ -154,7 +154,7 @@ class ConvertFullyConnectedLayer
       return rewriter.notifyMatchFailure(op, msg);
     };
     auto dotGeneralOp =
-        dyn_cast<stablehlo::DotGeneralOp>(op.getOperand().getDefiningOp());
+        op.getOperand().getDefiningOp<stablehlo::DotGeneralOp>();
     if (!dotGeneralOp) {
       return error("expected stablehlo.dot_general as input");
     }

--- a/samples/compiler_plugins/xnnpack/test/stablehlo-to-xnnpack.mlir
+++ b/samples/compiler_plugins/xnnpack/test/stablehlo-to-xnnpack.mlir
@@ -22,3 +22,9 @@ func.func @fully_connected$transpose(%input : tensor<1x100x200xi8>, %kernel : te
   %out = stablehlo.convert %dot_general : (tensor<1x100x300xi32>) -> tensor<1x100x300xf32>
   return %out : tensor<1x100x300xf32>
 }
+
+// CHECK-LABEL:   func.func @fully_connected$no_defining_op_for_convert_operand(
+func.func @fully_connected$no_defining_op_for_convert_operand(%input : tensor<i8>) -> tensor<i16> {
+  %out = stablehlo.convert %input : (tensor<i8>) -> tensor<i16>
+  return %out : tensor<i16>
+}


### PR DESCRIPTION
The `dyn_cast` function will assert that the `Operation*` passed actually exists, but `getDefiningOp()` is not guaranteed to return an existing operation. This commit moves the casting to the `getDefiningOp` call to avoid the failed assert.