### PR TITLE
Convert kernel to unsigned before passing to fully_connected op

### DIFF
--- a/samples/compiler_plugins/xnnpack/test/fully-connected-e2e.mlir
+++ b/samples/compiler_plugins/xnnpack/test/fully-connected-e2e.mlir
@@ -5,7 +5,7 @@
 // RUN:     --module=- \
 // RUN:     --function=main \
 // RUN:     --input=1x2x8xi8=1 \
-// RUN:     --input=4x8xui8=2 --xnnpack_thread_count=2 | \
+// RUN:     --input=4x8xi8=2 --xnnpack_thread_count=2 | \
 // RUN: FileCheck %s --check-prefix=CHECK-SYSTEM
 
 // CHECK-SYSTEM: EXEC @main

--- a/samples/compiler_plugins/xnnpack/test/fully-connected-e2e.mlir
+++ b/samples/compiler_plugins/xnnpack/test/fully-connected-e2e.mlir
@@ -5,16 +5,20 @@
 // RUN:     --module=- \
 // RUN:     --function=main \
 // RUN:     --input=1x2x8xi8=1 \
-// RUN:     --input=4x8xi8=2 \
-// RUN:     --input=4x8xi8=8 --xnnpack_thread_count=2 | \
+// RUN:     --input=4x8xui8=2 --xnnpack_thread_count=2 | \
 // RUN: FileCheck %s --check-prefix=CHECK-SYSTEM
 
 // CHECK-SYSTEM: EXEC @main
 // CHECK-SYSTEM: 1x2x4xf32={{\[}}[16 16 16 16][16 16 16 16]]
-func.func @main(%input : tensor<1x2x8xi8>, %kernel : tensor<4x8xi8>, %offset : tensor<4x8xi8>) -> tensor<1x2x4xf32> {
-  // TODO: Avoid doing this addition.
-  // Currently, XNNPACK will subtract the kernel by 8, so here 8 is added to the weight.
-  %kernel_adjusted = stablehlo.add %kernel, %offset : (tensor<4x8xi8>, tensor<4x8xi8>) -> tensor<4x8xi8>
+func.func @main(%input : tensor<1x2x8xi8>, %kernel : tensor<4x8xi8>) -> tensor<1x2x4xf32> {
+  // TODO: Avoid doing this XOR.
+  // Currently, XNNPACK assumes the kernel is an `ui4`
+  // tensor. However, doing an `ui8->i4` conversion does not result in
+  // a `ui4` tensor, and a `ui8->ui4` conversion is currently not
+  // handled by IREE. Therefore, we manually convert to unsign by
+  // XORing.
+  %c8 = stablehlo.constant dense<8> : tensor<4x8xi8>
+  %kernel_adjusted = stablehlo.xor %kernel, %c8 : (tensor<4x8xi8>, tensor<4x8xi8>) -> tensor<4x8xi8>
   %kernel_i4 = stablehlo.convert %kernel_adjusted : (tensor<4x8xi8>) -> tensor<4x8xi4>
   %c = xnnpack.fully_connected_nc_qd8_f32_qc4w %input, %kernel_i4 : (tensor<1x2x8xi8>, tensor<4x8xi4>) -> tensor<1x2x4xf32>
   func.return %c : tensor<1x2x4xf32>

--- a/samples/compiler_plugins/xnnpack/test/stablehlo-to-xnnpack.mlir
+++ b/samples/compiler_plugins/xnnpack/test/stablehlo-to-xnnpack.mlir
@@ -3,7 +3,10 @@
 // CHECK-LABEL:   func.func @fully_connected(
 // CHECK-SAME:                           %[[LHS:.*]]: tensor<1x100x200xi8>,
 // CHECK-SAME:                           %[[RHS:.*]]: tensor<300x200xi4>) -> tensor<1x100x300xf32> {
-// CHECK:           %{{.*}} = xnnpack.fully_connected_nc_qd8_f32_qc4w %[[LHS]], %[[RHS]] : (tensor<1x100x200xi8>, tensor<300x200xi4>) -> tensor<1x100x300xf32>
+// CHECK:           %[[C8:.*]] = stablehlo.constant dense<8>
+// CHECK:           %[[C8_I4:.*]] = stablehlo.convert %[[C8]] : (tensor<{{.*}}i8>) -> tensor<{{.*}}i4>
+// CHECK:           %[[RHS_UI4:.*]] = stablehlo.xor %[[RHS]], %[[C8_I4]]
+// CHECK:           %{{.*}} = xnnpack.fully_connected_nc_qd8_f32_qc4w %[[LHS]], %[[RHS_UI4]] : (tensor<1x100x200xi8>, tensor<300x200xi4>) -> tensor<1x100x300xf32>
 func.func @fully_connected(%input : tensor<1x100x200xi8>, %kernel : tensor<300x200xi4>) -> tensor<1x100x300xf32> {
   %kernel_cast = stablehlo.convert %kernel : (tensor<300x200xi4>) -> tensor<300x200xi8>
   %dot_general = stablehlo.dot_general %input, %kernel_cast, contracting_dims = [2] x [1], precision = [DEFAULT, DEFAULT] : (tensor<1x100x200xi8>, tensor<300x200xi8>) -> tensor<1x100x300xi32>
@@ -14,8 +17,11 @@ func.func @fully_connected(%input : tensor<1x100x200xi8>, %kernel : tensor<300x2
 // CHECK-LABEL:   func.func @fully_connected$transpose(
 // CHECK-SAME:                                     %[[LHS:.*]]: tensor<1x100x200xi8>,
 // CHECK-SAME:                                     %[[RHS:.*]]: tensor<200x300xi4>) -> tensor<1x100x300xf32> {
+// CHECK:           %[[C8:.*]] = stablehlo.constant dense<8>
 // CHECK:           %[[TRANSPOSE:.*]] = stablehlo.transpose %[[RHS]], dims = [1, 0] : (tensor<200x300xi4>) -> tensor<300x200xi4>
-// CHECK:           %{{.*}} = xnnpack.fully_connected_nc_qd8_f32_qc4w %[[LHS]], %[[TRANSPOSE]] : (tensor<1x100x200xi8>, tensor<300x200xi4>) -> tensor<1x100x300xf32>
+// CHECK:           %[[C8_I4:.*]] = stablehlo.convert %[[C8]] : (tensor<{{.*}}xi8>) -> tensor<{{.*}}xi4>
+// CHECK:           %[[TRANSPOSE_UI4:.*]] = stablehlo.xor %[[TRANSPOSE]], %[[C8_I4]]
+// CHECK:           %{{.*}} = xnnpack.fully_connected_nc_qd8_f32_qc4w %[[LHS]], %[[TRANSPOSE_UI4]] : (tensor<1x100x200xi8>, tensor<300x200xi4>) -> tensor<1x100x300xf32>
 func.func @fully_connected$transpose(%input : tensor<1x100x200xi8>, %kernel : tensor<200x300xi4>) -> tensor<1x100x300xf32> {
   %kernel_cast = stablehlo.convert %kernel : (tensor<200x300xi4>) -> tensor<200x300xi8>
   %dot_general = stablehlo.dot_general %input, %kernel_cast, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<1x100x200xi8>, tensor<200x300xi8>) -> tensor<1x100x300xi32>


### PR DESCRIPTION
XNNPACK currently expects the input kernel tensor to be of type `ui4`. This commit add the conversion to unsigned by manually XORing the kernel tensor with the value 8.

Note: doing an `ui8->i4` conversion does not result in a `ui4` tensor, and a `ui8->ui4` conversion is currently not handled by IREE. Therefore, we manually convert to unsign by XORing.