### PR TITLE
Add transpose attribute to fully_connected op

### DIFF
--- a/samples/compiler_plugins/xnnpack/BUILD.bazel
+++ b/samples/compiler_plugins/xnnpack/BUILD.bazel
@@ -69,6 +69,7 @@ cc_library(
     deps = [
         ":XnnpackOpsGen",
         ":defs",
+        "@llvm-project//mlir:BytecodeOpInterface",
         "@llvm-project//mlir:IR",
     ],
 )

--- a/samples/compiler_plugins/xnnpack/CMakeLists.txt
+++ b/samples/compiler_plugins/xnnpack/CMakeLists.txt
@@ -55,6 +55,7 @@ iree_cc_library(
   DEPS
     ::XnnpackOpsGen
     ::defs
+    MLIRBytecodeOpInterface
     MLIRIR
   PUBLIC
 )

--- a/samples/compiler_plugins/xnnpack/src/xnnpack/IR/XnnpackOps.h
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack/IR/XnnpackOps.h
@@ -7,6 +7,7 @@
 #ifndef IREE_SAMPLES_COMPILER_PLUGINS_XNNPACK_IR_XNNPACKOPS_H_
 #define IREE_SAMPLES_COMPILER_PLUGINS_XNNPACK_IR_XNNPACKOPS_H_
 
+#include "mlir/Bytecode/BytecodeOpInterface.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Operation.h"
 

--- a/samples/compiler_plugins/xnnpack/src/xnnpack/IR/XnnpackOps.td
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack/IR/XnnpackOps.td
@@ -45,11 +45,11 @@ def Xnnpack_FullyConnectedNcQd8F32Qc4wOp : Xnnpack_Op<"fully_connected_nc_qd8_f3
   let summary = "Fully connected layer with int8 input, int4 kernel, and f32 output";
   let arguments = (ins AnyRankedTensor:$input,
                        AnyRankedTensor:$kernel,
-                       BoolAttr:$kernel_needs_transpose);
+                       BoolAttr:$transpose_rhs);
   let results = (outs AnyRankedTensor:$result);
 
   let assemblyFormat = [{
-    $input `,` $kernel `kernel_needs_transpose` `=` $kernel_needs_transpose attr-dict `:` functional-type(operands, results)
+    $input `,` $kernel `transpose_rhs` `=` $transpose_rhs attr-dict `:` functional-type(operands, results)
   }];
 }
 

--- a/samples/compiler_plugins/xnnpack/src/xnnpack/IR/XnnpackOps.td
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack/IR/XnnpackOps.td
@@ -44,11 +44,12 @@ def Xnnpack_BatchMatrixMultiplyOp : Xnnpack_Op<"batch_matrix_multiply", []> {
 def Xnnpack_FullyConnectedNcQd8F32Qc4wOp : Xnnpack_Op<"fully_connected_nc_qd8_f32_qc4w", []> {
   let summary = "Fully connected layer with int8 input, int4 kernel, and f32 output";
   let arguments = (ins AnyRankedTensor:$input,
-                       AnyRankedTensor:$kernel);
+                       AnyRankedTensor:$kernel,
+                       BoolAttr:$kernel_needs_transpose);
   let results = (outs AnyRankedTensor:$result);
 
   let assemblyFormat = [{
-    $input `,` $kernel attr-dict `:` functional-type(operands, results)
+    $input `,` $kernel `kernel_needs_transpose` `=` $kernel_needs_transpose attr-dict `:` functional-type(operands, results)
   }];
 }
 

--- a/samples/compiler_plugins/xnnpack/src/xnnpack/Transforms/LegalizeXnnpack.cpp
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack/Transforms/LegalizeXnnpack.cpp
@@ -105,9 +105,8 @@ static FailureOr<SmallVector<SmallVector<Value>>> getInputOutputDims(
     // `kernel` tensor when no transpose is needed for the `kernel` tensor, and
     // a reduction along the inner dimension otherwise.
     SmallVector<Value> outputDims(inputDims.drop_back(1));
-    outputDims.push_back(fullyConnected.getKernelNeedsTranspose()
-                             ? kernelDims[1]
-                             : kernelDims[0]);
+    outputDims.push_back(fullyConnected.getTransposeRhs() ? kernelDims[1]
+                                                          : kernelDims[0]);
     dims.push_back(outputDims);
   } else {
     llvm_unreachable("not an xnnpack op!");

--- a/samples/compiler_plugins/xnnpack/src/xnnpack/Transforms/LegalizeXnnpack.cpp
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack/Transforms/LegalizeXnnpack.cpp
@@ -98,10 +98,17 @@ static FailureOr<SmallVector<SmallVector<Value>>> getInputOutputDims(
     if (kernelType.getRank() != 2) {
       return op->emitError("unimplemented: kernel of rank != 2");
     }
-    // Fully connected performs a reduction along the right-most dimension of
-    // the input and the kernel.
-    // output shape = [input.dim(0), input.dim(1), kernel.dim(0)]
-    dims.push_back({dims[0][0], dims[0][1], dims[1][0]});
+
+    ArrayRef<Value> inputDims(dims[0]);
+    ArrayRef<Value> kernelDims(dims[1]);
+    // Fully connected performs a reduction along the outer dimension of the
+    // `kernel` tensor when no transpose is needed for the `kernel` tensor, and
+    // a reduction along the inner dimension otherwise.
+    SmallVector<Value> outputDims(inputDims.drop_back(1));
+    outputDims.push_back(fullyConnected.getKernelNeedsTranspose()
+                             ? kernelDims[1]
+                             : kernelDims[0]);
+    dims.push_back(outputDims);
   } else {
     llvm_unreachable("not an xnnpack op!");
   }
@@ -151,6 +158,17 @@ static FailureOr<func::FuncOp> createUKernelGeneric(
 
           SmallVector<Value> otherOperands;
           for (auto dims : maybeDims.value()) otherOperands.append(dims);
+          for (auto attr : op->getAttrs()) {
+            if (auto boolAttr = dyn_cast<BoolAttr>(attr.getValue())) {
+              Value boolVal = rewriter.create<arith::ConstantIntOp>(
+                  loc, boolAttr.getValue(), 8);
+              otherOperands.push_back(boolVal);
+            } else {
+              return op->emitError()
+                     << "unimplemented: handling of attribute with value '"
+                     << attr.getValue() << "'";
+            }
+          }
 
           auto ukernel =
               rewriter

--- a/samples/compiler_plugins/xnnpack/test/fully-connected-e2e.mlir
+++ b/samples/compiler_plugins/xnnpack/test/fully-connected-e2e.mlir
@@ -20,6 +20,6 @@ func.func @main(%input : tensor<1x2x8xi8>, %kernel : tensor<4x8xi8>) -> tensor<1
   %c8 = stablehlo.constant dense<8> : tensor<4x8xi8>
   %kernel_adjusted = stablehlo.xor %kernel, %c8 : (tensor<4x8xi8>, tensor<4x8xi8>) -> tensor<4x8xi8>
   %kernel_i4 = stablehlo.convert %kernel_adjusted : (tensor<4x8xi8>) -> tensor<4x8xi4>
-  %c = xnnpack.fully_connected_nc_qd8_f32_qc4w %input, %kernel_i4 : (tensor<1x2x8xi8>, tensor<4x8xi4>) -> tensor<1x2x4xf32>
+  %c = xnnpack.fully_connected_nc_qd8_f32_qc4w %input, %kernel_i4 kernel_needs_transpose = false : (tensor<1x2x8xi8>, tensor<4x8xi4>) -> tensor<1x2x4xf32>
   func.return %c : tensor<1x2x4xf32>
 }

--- a/samples/compiler_plugins/xnnpack/test/fully-connected-e2e.mlir
+++ b/samples/compiler_plugins/xnnpack/test/fully-connected-e2e.mlir
@@ -20,6 +20,6 @@ func.func @main(%input : tensor<1x2x8xi8>, %kernel : tensor<4x8xi8>) -> tensor<1
   %c8 = stablehlo.constant dense<8> : tensor<4x8xi8>
   %kernel_adjusted = stablehlo.xor %kernel, %c8 : (tensor<4x8xi8>, tensor<4x8xi8>) -> tensor<4x8xi8>
   %kernel_i4 = stablehlo.convert %kernel_adjusted : (tensor<4x8xi8>) -> tensor<4x8xi4>
-  %c = xnnpack.fully_connected_nc_qd8_f32_qc4w %input, %kernel_i4 kernel_needs_transpose = false : (tensor<1x2x8xi8>, tensor<4x8xi4>) -> tensor<1x2x4xf32>
+  %c = xnnpack.fully_connected_nc_qd8_f32_qc4w %input, %kernel_i4 transpose_rhs = false : (tensor<1x2x8xi8>, tensor<4x8xi4>) -> tensor<1x2x4xf32>
   func.return %c : tensor<1x2x4xf32>
 }

--- a/samples/compiler_plugins/xnnpack/test/fully-connected-transpose-e2e.mlir
+++ b/samples/compiler_plugins/xnnpack/test/fully-connected-transpose-e2e.mlir
@@ -18,6 +18,6 @@ func.func @main(%input : tensor<1x2x8xi8>, %kernel : tensor<8x4xi8>) -> tensor<1
   %c8 = stablehlo.constant dense<8> : tensor<8x4xi8>
   %kernel_adjusted = stablehlo.xor %kernel, %c8 : (tensor<8x4xi8>, tensor<8x4xi8>) -> tensor<8x4xi8>
   %kernel_i4 = stablehlo.convert %kernel_adjusted : (tensor<8x4xi8>) -> tensor<8x4xi4>
-  %c = xnnpack.fully_connected_nc_qd8_f32_qc4w %input, %kernel_i4 kernel_needs_transpose = true : (tensor<1x2x8xi8>, tensor<8x4xi4>) -> tensor<1x2x4xf32>
+  %c = xnnpack.fully_connected_nc_qd8_f32_qc4w %input, %kernel_i4 transpose_rhs = true : (tensor<1x2x8xi8>, tensor<8x4xi4>) -> tensor<1x2x4xf32>
   func.return %c : tensor<1x2x4xf32>
 }

--- a/samples/compiler_plugins/xnnpack/test/fully-connected-transpose-e2e.mlir
+++ b/samples/compiler_plugins/xnnpack/test/fully-connected-transpose-e2e.mlir
@@ -1,0 +1,23 @@
+// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --iree-plugin=xnnpack %s | \
+// RUN: iree-run-module \
+// RUN:     --device=local-sync \
+// RUN:     --executable_plugin=$IREE_BINARY_DIR/samples/custom_dispatch/xnnpack/plugin/system_plugin$IREE_DYLIB_EXT \
+// RUN:     --module=- \
+// RUN:     --function=main \
+// RUN:     --input=1x2x8xi8=1 \
+// RUN:     --input=8x4xi8=2 --xnnpack_thread_count=2 | \
+// RUN: FileCheck %s --check-prefix=CHECK-SYSTEM
+
+// CHECK-SYSTEM: EXEC @main
+// CHECK-SYSTEM: 1x2x4xf32={{\[}}[16 16 16 16][16 16 16 16]]
+func.func @main(%input : tensor<1x2x8xi8>, %kernel : tensor<8x4xi8>) -> tensor<1x2x4xf32> {
+  // XNNPACK expects the `kernel` tensor to have unsigned values with
+  // zero point of 8. The XOR operation transforms the `kernel` tensor
+  // from having zero point of 0 to having zero point of 8 (i.e. going
+  // from signed i4 space to unsigned i4 space).
+  %c8 = stablehlo.constant dense<8> : tensor<8x4xi8>
+  %kernel_adjusted = stablehlo.xor %kernel, %c8 : (tensor<8x4xi8>, tensor<8x4xi8>) -> tensor<8x4xi8>
+  %kernel_i4 = stablehlo.convert %kernel_adjusted : (tensor<8x4xi8>) -> tensor<8x4xi4>
+  %c = xnnpack.fully_connected_nc_qd8_f32_qc4w %input, %kernel_i4 kernel_needs_transpose = true : (tensor<1x2x8xi8>, tensor<8x4xi4>) -> tensor<1x2x4xf32>
+  func.return %c : tensor<1x2x4xf32>
+}

--- a/samples/compiler_plugins/xnnpack/test/patterns.pdll
+++ b/samples/compiler_plugins/xnnpack/test/patterns.pdll
@@ -23,5 +23,6 @@ Pattern {
   CheckInnermostReduction(dot_general);
   CheckF32RankedTensorType(cvt_i32_f32);
 
-  replace cvt_i32_f32 with op<xnnpack.fully_connected_nc_qd8_f32_qc4w>(i8_input, i4_input);
+  replace cvt_i32_f32 with op<xnnpack.fully_connected_nc_qd8_f32_qc4w>(i8_input, i4_input)
+      { kernel_needs_transpose = attr<"false"> };
 }

--- a/samples/compiler_plugins/xnnpack/test/patterns.pdll
+++ b/samples/compiler_plugins/xnnpack/test/patterns.pdll
@@ -24,5 +24,5 @@ Pattern {
   CheckF32RankedTensorType(cvt_i32_f32);
 
   replace cvt_i32_f32 with op<xnnpack.fully_connected_nc_qd8_f32_qc4w>(i8_input, i4_input)
-      { kernel_needs_transpose = attr<"false"> };
+      { transpose_rhs = attr<"false"> };
 }

--- a/samples/compiler_plugins/xnnpack/test/stablehlo-to-xnnpack-using-pdll.mlir
+++ b/samples/compiler_plugins/xnnpack/test/stablehlo-to-xnnpack-using-pdll.mlir
@@ -15,7 +15,7 @@ func.func @multiply(%a : tensor<100x200xi8>, %b : tensor<100x200xi8>) -> tensor<
 // CHECK-LABEL:   func.func @fully_connected(
 // CHECK-SAME:                           %[[LHS:.*]]: tensor<1x100x200xi8>,
 // CHECK-SAME:                           %[[RHS:.*]]: tensor<300x200xi4>) -> tensor<1x100x300xf32> {
-// CHECK:           %{{.*}} = xnnpack.fully_connected_nc_qd8_f32_qc4w %[[LHS]], %[[RHS]] : (tensor<1x100x200xi8>, tensor<300x200xi4>) -> tensor<1x100x300xf32>
+// CHECK:           %{{.*}} = xnnpack.fully_connected_nc_qd8_f32_qc4w %[[LHS]], %[[RHS]] kernel_needs_transpose = false : (tensor<1x100x200xi8>, tensor<300x200xi4>) -> tensor<1x100x300xf32>
 func.func @fully_connected(%input : tensor<1x100x200xi8>, %weight : tensor<300x200xi4>) -> tensor<1x100x300xf32> {
   %weight_cast = stablehlo.convert %weight : (tensor<300x200xi4>) -> tensor<300x200xi8>
   %dot_general = stablehlo.dot_general %input, %weight_cast, contracting_dims = [2] x [1], precision = [DEFAULT, DEFAULT] : (tensor<1x100x200xi8>, tensor<300x200xi8>) -> tensor<1x100x300xi32>

--- a/samples/compiler_plugins/xnnpack/test/stablehlo-to-xnnpack-using-pdll.mlir
+++ b/samples/compiler_plugins/xnnpack/test/stablehlo-to-xnnpack-using-pdll.mlir
@@ -15,7 +15,7 @@ func.func @multiply(%a : tensor<100x200xi8>, %b : tensor<100x200xi8>) -> tensor<
 // CHECK-LABEL:   func.func @fully_connected(
 // CHECK-SAME:                           %[[LHS:.*]]: tensor<1x100x200xi8>,
 // CHECK-SAME:                           %[[RHS:.*]]: tensor<300x200xi4>) -> tensor<1x100x300xf32> {
-// CHECK:           %{{.*}} = xnnpack.fully_connected_nc_qd8_f32_qc4w %[[LHS]], %[[RHS]] kernel_needs_transpose = false : (tensor<1x100x200xi8>, tensor<300x200xi4>) -> tensor<1x100x300xf32>
+// CHECK:           %{{.*}} = xnnpack.fully_connected_nc_qd8_f32_qc4w %[[LHS]], %[[RHS]] transpose_rhs = false : (tensor<1x100x200xi8>, tensor<300x200xi4>) -> tensor<1x100x300xf32>
 func.func @fully_connected(%input : tensor<1x100x200xi8>, %weight : tensor<300x200xi4>) -> tensor<1x100x300xf32> {
   %weight_cast = stablehlo.convert %weight : (tensor<300x200xi4>) -> tensor<300x200xi8>
   %dot_general = stablehlo.dot_general %input, %weight_cast, contracting_dims = [2] x [1], precision = [DEFAULT, DEFAULT] : (tensor<1x100x200xi8>, tensor<300x200xi8>) -> tensor<1x100x300xi32>

--- a/samples/compiler_plugins/xnnpack/test/stablehlo-to-xnnpack.mlir
+++ b/samples/compiler_plugins/xnnpack/test/stablehlo-to-xnnpack.mlir
@@ -6,7 +6,7 @@
 // CHECK:           %[[C8:.*]] = stablehlo.constant dense<8>
 // CHECK:           %[[C8_I4:.*]] = stablehlo.convert %[[C8]] : (tensor<{{.*}}i8>) -> tensor<{{.*}}i4>
 // CHECK:           %[[RHS_UI4:.*]] = stablehlo.xor %[[RHS]], %[[C8_I4]]
-// CHECK:           %{{.*}} = xnnpack.fully_connected_nc_qd8_f32_qc4w %[[LHS]], %[[RHS_UI4]] kernel_needs_transpose = false : (tensor<1x100x200xi8>, tensor<300x200xi4>) -> tensor<1x100x300xf32>
+// CHECK:           %{{.*}} = xnnpack.fully_connected_nc_qd8_f32_qc4w %[[LHS]], %[[RHS_UI4]] transpose_rhs = false : (tensor<1x100x200xi8>, tensor<300x200xi4>) -> tensor<1x100x300xf32>
 func.func @fully_connected(%input : tensor<1x100x200xi8>, %kernel : tensor<300x200xi4>) -> tensor<1x100x300xf32> {
   %kernel_cast = stablehlo.convert %kernel : (tensor<300x200xi4>) -> tensor<300x200xi8>
   %dot_general = stablehlo.dot_general %input, %kernel_cast, contracting_dims = [2] x [1], precision = [DEFAULT, DEFAULT] : (tensor<1x100x200xi8>, tensor<300x200xi8>) -> tensor<1x100x300xi32>
@@ -20,7 +20,7 @@ func.func @fully_connected(%input : tensor<1x100x200xi8>, %kernel : tensor<300x2
 // CHECK:           %[[C8:.*]] = stablehlo.constant dense<8>
 // CHECK:           %[[C8_I4:.*]] = stablehlo.convert %[[C8]] : (tensor<{{.*}}xi8>) -> tensor<{{.*}}xi4>
 // CHECK:           %[[RHS_UI4:.*]] = stablehlo.xor %[[RHS]], %[[C8_I4]]
-// CHECK:           %{{.*}} = xnnpack.fully_connected_nc_qd8_f32_qc4w %[[LHS]], %[[RHS_UI4]] kernel_needs_transpose = true : (tensor<1x100x200xi8>, tensor<200x300xi4>) -> tensor<1x100x300xf32>
+// CHECK:           %{{.*}} = xnnpack.fully_connected_nc_qd8_f32_qc4w %[[LHS]], %[[RHS_UI4]] transpose_rhs = true : (tensor<1x100x200xi8>, tensor<200x300xi4>) -> tensor<1x100x300xf32>
 func.func @fully_connected$transpose(%input : tensor<1x100x200xi8>, %kernel : tensor<200x300xi4>) -> tensor<1x100x300xf32> {
   %kernel_cast = stablehlo.convert %kernel : (tensor<200x300xi4>) -> tensor<200x300xi8>
   %dot_general = stablehlo.dot_general %input, %kernel_cast, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<1x100x200xi8>, tensor<200x300xi8>) -> tensor<1x100x300xi32>

--- a/samples/compiler_plugins/xnnpack/test/stablehlo-to-xnnpack.mlir
+++ b/samples/compiler_plugins/xnnpack/test/stablehlo-to-xnnpack.mlir
@@ -6,7 +6,7 @@
 // CHECK:           %[[C8:.*]] = stablehlo.constant dense<8>
 // CHECK:           %[[C8_I4:.*]] = stablehlo.convert %[[C8]] : (tensor<{{.*}}i8>) -> tensor<{{.*}}i4>
 // CHECK:           %[[RHS_UI4:.*]] = stablehlo.xor %[[RHS]], %[[C8_I4]]
-// CHECK:           %{{.*}} = xnnpack.fully_connected_nc_qd8_f32_qc4w %[[LHS]], %[[RHS_UI4]] : (tensor<1x100x200xi8>, tensor<300x200xi4>) -> tensor<1x100x300xf32>
+// CHECK:           %{{.*}} = xnnpack.fully_connected_nc_qd8_f32_qc4w %[[LHS]], %[[RHS_UI4]] kernel_needs_transpose = false : (tensor<1x100x200xi8>, tensor<300x200xi4>) -> tensor<1x100x300xf32>
 func.func @fully_connected(%input : tensor<1x100x200xi8>, %kernel : tensor<300x200xi4>) -> tensor<1x100x300xf32> {
   %kernel_cast = stablehlo.convert %kernel : (tensor<300x200xi4>) -> tensor<300x200xi8>
   %dot_general = stablehlo.dot_general %input, %kernel_cast, contracting_dims = [2] x [1], precision = [DEFAULT, DEFAULT] : (tensor<1x100x200xi8>, tensor<300x200xi8>) -> tensor<1x100x300xi32>
@@ -18,10 +18,9 @@ func.func @fully_connected(%input : tensor<1x100x200xi8>, %kernel : tensor<300x2
 // CHECK-SAME:                                     %[[LHS:.*]]: tensor<1x100x200xi8>,
 // CHECK-SAME:                                     %[[RHS:.*]]: tensor<200x300xi4>) -> tensor<1x100x300xf32> {
 // CHECK:           %[[C8:.*]] = stablehlo.constant dense<8>
-// CHECK:           %[[TRANSPOSE:.*]] = stablehlo.transpose %[[RHS]], dims = [1, 0] : (tensor<200x300xi4>) -> tensor<300x200xi4>
 // CHECK:           %[[C8_I4:.*]] = stablehlo.convert %[[C8]] : (tensor<{{.*}}xi8>) -> tensor<{{.*}}xi4>
-// CHECK:           %[[TRANSPOSE_UI4:.*]] = stablehlo.xor %[[TRANSPOSE]], %[[C8_I4]]
-// CHECK:           %{{.*}} = xnnpack.fully_connected_nc_qd8_f32_qc4w %[[LHS]], %[[TRANSPOSE_UI4]] : (tensor<1x100x200xi8>, tensor<300x200xi4>) -> tensor<1x100x300xf32>
+// CHECK:           %[[RHS_UI4:.*]] = stablehlo.xor %[[RHS]], %[[C8_I4]]
+// CHECK:           %{{.*}} = xnnpack.fully_connected_nc_qd8_f32_qc4w %[[LHS]], %[[RHS_UI4]] kernel_needs_transpose = true : (tensor<1x100x200xi8>, tensor<200x300xi4>) -> tensor<1x100x300xf32>
 func.func @fully_connected$transpose(%input : tensor<1x100x200xi8>, %kernel : tensor<200x300xi4>) -> tensor<1x100x300xf32> {
   %kernel_cast = stablehlo.convert %kernel : (tensor<200x300xi4>) -> tensor<200x300xi8>
   %dot_general = stablehlo.dot_general %input, %kernel_cast, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<1x100x200xi8>, tensor<200x300xi8>) -> tensor<1x100x300xi32>

--- a/samples/compiler_plugins/xnnpack/test/xnnpack-legalize.mlir
+++ b/samples/compiler_plugins/xnnpack/test/xnnpack-legalize.mlir
@@ -30,7 +30,7 @@
 // CHECK-SAME:                                                               %[[B:.*]]: tensor<?x?xi4>) -> tensor<1x?x?xf32> {
 // CHECK:           %[[OUT:.*]] = tensor.empty(%[[A_DIM_1:.*]], %[[B_DIM_0:.*]]) : tensor<1x?x?xf32>
 // CHECK:           %[[RESULT:.*]] = flow.dispatch.region -> (tensor<1x?x?xf32>{%[[A_DIM_1]], %[[B_DIM_0]]}) {
-// CHECK:             %[[UKERNEL:.*]] = iree_codegen.ukernel.generic "xnnpack.fully_connected_nc_qd8_f32_qc4w_workgroup" ins(%[[A]], %[[B]] : tensor<1x?x?xi8>, tensor<?x?xi4>) outs(%[[OUT]] : tensor<1x?x?xf32>) (%[[A_DIM_0:.*]], %[[A_DIM_1]], %[[A_DIM_2:.*]], %[[B_DIM_0]], %[[B_DIM_1:.*]], %[[A_DIM_0]], %[[A_DIM_1]], %[[B_DIM_0]], %[[KERNEL_NEEDS_TRANSPOSE:.*]] : index, index, index, index, index, index, index, index, i8) -> tensor<1x?x?xf32>
+// CHECK:             %[[UKERNEL:.*]] = iree_codegen.ukernel.generic "xnnpack.fully_connected_nc_qd8_f32_qc4w_workgroup" ins(%[[A]], %[[B]] : tensor<1x?x?xi8>, tensor<?x?xi4>) outs(%[[OUT]] : tensor<1x?x?xf32>) (%[[A_DIM_0:.*]], %[[A_DIM_1]], %[[A_DIM_2:.*]], %[[B_DIM_0]], %[[B_DIM_1:.*]], %[[A_DIM_0]], %[[A_DIM_1]], %[[B_DIM_0]], %[[TRANSPOSE_RHS:.*]] : index, index, index, index, index, index, index, index, i8) -> tensor<1x?x?xf32>
 // CHECK:             flow.return %[[UKERNEL]] : tensor<1x?x?xf32>
 // CHECK:           } count() -> (index, index, index) {
 // CHECK:             %[[ONE:.*]] = arith.constant 1 : index
@@ -55,6 +55,6 @@ func.func @batch_matrix_multiply(%a : tensor<?x?x?xf32>, %b : tensor<?x?x?xf32>)
 // CHECK-LABEL:   func.func @fully_connected(
 // CHECK:           %{{.*}} = call @xnnpack.fully_connected_nc_qd8_f32_qc4w
 func.func @fully_connected(%a : tensor<1x?x?xi8>, %b : tensor<?x?xi4>) -> tensor<1x?x?xf32> {
-  %c = xnnpack.fully_connected_nc_qd8_f32_qc4w %a, %b kernel_needs_transpose = false : (tensor<1x?x?xi8>, tensor<?x?xi4>) -> tensor<1x?x?xf32>
+  %c = xnnpack.fully_connected_nc_qd8_f32_qc4w %a, %b transpose_rhs = false : (tensor<1x?x?xi8>, tensor<?x?xi4>) -> tensor<1x?x?xf32>
   func.return %c : tensor<1x?x?xf32>
 }

--- a/samples/compiler_plugins/xnnpack/test/xnnpack-legalize.mlir
+++ b/samples/compiler_plugins/xnnpack/test/xnnpack-legalize.mlir
@@ -30,7 +30,7 @@
 // CHECK-SAME:                                                               %[[B:.*]]: tensor<?x?xi4>) -> tensor<1x?x?xf32> {
 // CHECK:           %[[OUT:.*]] = tensor.empty(%[[A_DIM_1:.*]], %[[B_DIM_0:.*]]) : tensor<1x?x?xf32>
 // CHECK:           %[[RESULT:.*]] = flow.dispatch.region -> (tensor<1x?x?xf32>{%[[A_DIM_1]], %[[B_DIM_0]]}) {
-// CHECK:             %[[UKERNEL:.*]] = iree_codegen.ukernel.generic "xnnpack.fully_connected_nc_qd8_f32_qc4w_workgroup" ins(%[[A]], %[[B]] : tensor<1x?x?xi8>, tensor<?x?xi4>) outs(%[[OUT]] : tensor<1x?x?xf32>) (%[[A_DIM_0:.*]], %[[A_DIM_1]], %[[A_DIM_2:.*]], %[[B_DIM_0]], %[[B_DIM_1:.*]], %[[A_DIM_0]], %[[A_DIM_1]], %[[B_DIM_0]] : index, index, index, index, index, index, index, index) -> tensor<1x?x?xf32>
+// CHECK:             %[[UKERNEL:.*]] = iree_codegen.ukernel.generic "xnnpack.fully_connected_nc_qd8_f32_qc4w_workgroup" ins(%[[A]], %[[B]] : tensor<1x?x?xi8>, tensor<?x?xi4>) outs(%[[OUT]] : tensor<1x?x?xf32>) (%[[A_DIM_0:.*]], %[[A_DIM_1]], %[[A_DIM_2:.*]], %[[B_DIM_0]], %[[B_DIM_1:.*]], %[[A_DIM_0]], %[[A_DIM_1]], %[[B_DIM_0]], %[[KERNEL_NEEDS_TRANSPOSE:.*]] : index, index, index, index, index, index, index, index, i8) -> tensor<1x?x?xf32>
 // CHECK:             flow.return %[[UKERNEL]] : tensor<1x?x?xf32>
 // CHECK:           } count() -> (index, index, index) {
 // CHECK:             %[[ONE:.*]] = arith.constant 1 : index
@@ -55,6 +55,6 @@ func.func @batch_matrix_multiply(%a : tensor<?x?x?xf32>, %b : tensor<?x?x?xf32>)
 // CHECK-LABEL:   func.func @fully_connected(
 // CHECK:           %{{.*}} = call @xnnpack.fully_connected_nc_qd8_f32_qc4w
 func.func @fully_connected(%a : tensor<1x?x?xi8>, %b : tensor<?x?xi4>) -> tensor<1x?x?xf32> {
-  %c = xnnpack.fully_connected_nc_qd8_f32_qc4w %a, %b : (tensor<1x?x?xi8>, tensor<?x?xi4>) -> tensor<1x?x?xf32>
+  %c = xnnpack.fully_connected_nc_qd8_f32_qc4w %a, %b kernel_needs_transpose = false : (tensor<1x?x?xi8>, tensor<?x?xi4>) -> tensor<1x?x?xf32>
   func.return %c : tensor<1x?x?xf32>
 }

--- a/samples/custom_dispatch/xnnpack/plugin/system_plugin.c
+++ b/samples/custom_dispatch/xnnpack/plugin/system_plugin.c
@@ -73,6 +73,7 @@ static int fully_connected_nc_qd8_f32_qc4w_workgroup(void* params_ptr,
     size_t binding2_size0;
     size_t binding2_size1;
     size_t binding2_size2;
+    int8_t needs_transpose;
   } params_t;
   const params_t* params = (const params_t*)params_ptr;
 
@@ -81,12 +82,16 @@ static int fully_connected_nc_qd8_f32_qc4w_workgroup(void* params_ptr,
 
   enum xnn_status status;
   assert(params->binding0_size0 == 1 && "unsupported input size");
-  assert(params->binding0_size2 == params->binding1_size1 &&
-         "invalid fully connected reduction");
+  size_t input_reduction_dim_size = params->binding0_size2;
+  size_t kernel_reduction_dim_size =
+      params->needs_transpose ? params->binding1_size0 : params->binding1_size1;
+  assert(input_reduction_dim_size == kernel_reduction_dim_size &&
+         "reduction dimensions are not the same size");
 
   const size_t batch_size = params->binding0_size1;
   const size_t input_channels = params->binding0_size2;
-  const size_t output_channels = params->binding1_size0;
+  const size_t output_channels =
+      params->needs_transpose ? params->binding1_size1 : params->binding1_size0;
   assert((input_channels & 1) == 0 && "`input_channels` must be even");
   // TODO: XNNPACK expects this value to be 8. From testing, this value is
   // subtracted from the kernel before using it in the matrix multiplication.
@@ -109,10 +114,11 @@ static int fully_connected_nc_qd8_f32_qc4w_workgroup(void* params_ptr,
   for (size_t i = 0; i < output_channels; i++) kernel_scale[i] = 1;
 
   xnn_operator_t fc_op = NULL;
+  uint32_t flags = params->needs_transpose ? XNN_FLAG_TRANSPOSE_WEIGHTS : 0;
   status = xnn_create_fully_connected_nc_qd8_f32_qc4w(
       input_channels, output_channels, /*input_stride=*/input_channels,
       /*output_stride=*/output_channels, kernel_zero_point, kernel_scale,
-      kernel, /*bias=*/NULL, output_min, output_max, /*flags=*/0,
+      kernel, /*bias=*/NULL, output_min, output_max, flags,
       /*code_cache=*/NULL,
       /*weights_cache=*/NULL, &fc_op);
   assert(status == xnn_status_success && "unable to create fully connected op");


### PR DESCRIPTION
This commit adds an boolean attribute to the `fully_connected` XNNPACK op for specifying if the `kernel` tensor requires a transpose before the fully connected computation is performed. The attribute is then passed as the last argument in the `params` struct to the executable plugin, so that XNNPACK can perform the tranpose of the weight.

Future work includes adding the ability for specifying whether to make the transpose in stablehlo (as is done before this commit) or in XNNPACK.