### PR TITLE
Restrict fully_connected op to 2d input and output

### DIFF
--- a/samples/compiler_plugins/xnnpack/src/xnnpack/Transforms/LegalizeXnnpack.cpp
+++ b/samples/compiler_plugins/xnnpack/src/xnnpack/Transforms/LegalizeXnnpack.cpp
@@ -91,12 +91,11 @@ static FailureOr<SmallVector<SmallVector<Value>>> getInputOutputDims(
         fullyConnected.getInput().getType().cast<RankedTensorType>();
     auto kernelType =
         fullyConnected.getKernel().getType().cast<RankedTensorType>();
-    if (inputType.getRank() != 3 && inputType.getShape()[0] != 1) {
-      return op->emitError(
-          "unimplemented: input with rank != 3 and first dimension size != 1");
+    if (inputType.getRank() != 2) {
+      return op->emitError("input must be rank-2");
     }
     if (kernelType.getRank() != 2) {
-      return op->emitError("unimplemented: kernel of rank != 2");
+      return op->emitError("kernel must be rank-2");
     }
 
     ArrayRef<Value> inputDims(dims[0]);
@@ -104,7 +103,7 @@ static FailureOr<SmallVector<SmallVector<Value>>> getInputOutputDims(
     // Fully connected performs a reduction along the outer dimension of the
     // `kernel` tensor when no transpose is needed for the `kernel` tensor, and
     // a reduction along the inner dimension otherwise.
-    SmallVector<Value> outputDims(inputDims.drop_back(1));
+    SmallVector<Value> outputDims{inputDims[0]};
     outputDims.push_back(fullyConnected.getTransposeRhs() ? kernelDims[1]
                                                           : kernelDims[0]);
     dims.push_back(outputDims);

--- a/samples/compiler_plugins/xnnpack/test/batch-matrix-multiply-e2e.mlir
+++ b/samples/compiler_plugins/xnnpack/test/batch-matrix-multiply-e2e.mlir
@@ -1,4 +1,6 @@
-// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --iree-plugin=xnnpack %s | \
+// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --iree-plugin=xnnpack --compile-to=flow %s | \
+// RUN: iree-opt --inline | \
+// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --compile-from=flow - | \
 // RUN: iree-run-module \
 // RUN:     --device=local-sync \
 // RUN:     --executable_plugin=$IREE_BINARY_DIR/samples/custom_dispatch/xnnpack/plugin/system_plugin$IREE_DYLIB_EXT \
@@ -11,7 +13,7 @@
 
 // CHECK-SYSTEM: EXEC @main
 // CHECK-SYSTEM: 2x2x2xf32={{\[}}[16 16][16 16]]{{\[}}[16 16][16 16]]
-func.func @main(%a : tensor<?x2x2xf32>, %b : tensor<?x2x2xf32>) -> tensor<?x2x2xf32> {
-  %c = xnnpack.batch_matrix_multiply %a, %b : (tensor<?x2x2xf32>, tensor<?x2x2xf32>) -> tensor<?x2x2xf32>
-  func.return %c : tensor<?x2x2xf32>
+func.func @main(%a : tensor<2x2x2xf32>, %b : tensor<2x2x2xf32>) -> tensor<2x2x2xf32> {
+  %c = xnnpack.batch_matrix_multiply %a, %b : (tensor<2x2x2xf32>, tensor<2x2x2xf32>) -> tensor<2x2x2xf32>
+  func.return %c : tensor<2x2x2xf32>
 }

--- a/samples/compiler_plugins/xnnpack/test/fully-connected-e2e.mlir
+++ b/samples/compiler_plugins/xnnpack/test/fully-connected-e2e.mlir
@@ -1,16 +1,18 @@
-// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --iree-plugin=xnnpack %s | \
+// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --iree-plugin=xnnpack --compile-to=flow %s | \
+// RUN: iree-opt --inline | \
+// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --compile-from=flow - | \
 // RUN: iree-run-module \
 // RUN:     --device=local-sync \
 // RUN:     --executable_plugin=$IREE_BINARY_DIR/samples/custom_dispatch/xnnpack/plugin/system_plugin$IREE_DYLIB_EXT \
 // RUN:     --module=- \
 // RUN:     --function=main \
-// RUN:     --input=1x2x8xi8=1 \
+// RUN:     --input=2x8xi8=1 \
 // RUN:     --input=4x8xi8=2 --xnnpack_thread_count=2 | \
 // RUN: FileCheck %s --check-prefix=CHECK-SYSTEM
 
 // CHECK-SYSTEM: EXEC @main
-// CHECK-SYSTEM: 1x2x4xf32={{\[}}[16 16 16 16][16 16 16 16]]
-func.func @main(%input : tensor<1x2x8xi8>, %kernel : tensor<4x8xi8>) -> tensor<1x2x4xf32> {
+// CHECK-SYSTEM: 2x4xf32=[16 16 16 16][16 16 16 16]
+func.func @main(%input : tensor<2x8xi8>, %kernel : tensor<4x8xi8>) -> tensor<2x4xf32> {
   // TODO: Avoid doing this XOR.
   // Currently, XNNPACK assumes the kernel is an `ui4`
   // tensor. However, doing an `ui8->i4` conversion does not result in
@@ -20,6 +22,6 @@ func.func @main(%input : tensor<1x2x8xi8>, %kernel : tensor<4x8xi8>) -> tensor<1
   %c8 = stablehlo.constant dense<8> : tensor<4x8xi8>
   %kernel_adjusted = stablehlo.xor %kernel, %c8 : (tensor<4x8xi8>, tensor<4x8xi8>) -> tensor<4x8xi8>
   %kernel_i4 = stablehlo.convert %kernel_adjusted : (tensor<4x8xi8>) -> tensor<4x8xi4>
-  %c = xnnpack.fully_connected_nc_qd8_f32_qc4w %input, %kernel_i4 transpose_rhs = false : (tensor<1x2x8xi8>, tensor<4x8xi4>) -> tensor<1x2x4xf32>
-  func.return %c : tensor<1x2x4xf32>
+  %c = xnnpack.fully_connected_nc_qd8_f32_qc4w %input, %kernel_i4 transpose_rhs = false : (tensor<2x8xi8>, tensor<4x8xi4>) -> tensor<2x4xf32>
+  func.return %c : tensor<2x4xf32>
 }

--- a/samples/compiler_plugins/xnnpack/test/fully-connected-transpose-e2e.mlir
+++ b/samples/compiler_plugins/xnnpack/test/fully-connected-transpose-e2e.mlir
@@ -1,16 +1,18 @@
-// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --iree-plugin=xnnpack %s | \
+// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --iree-plugin=xnnpack --compile-to=flow %s | \
+// RUN: iree-opt --inline | \
+// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --compile-from=flow - | \
 // RUN: iree-run-module \
 // RUN:     --device=local-sync \
 // RUN:     --executable_plugin=$IREE_BINARY_DIR/samples/custom_dispatch/xnnpack/plugin/system_plugin$IREE_DYLIB_EXT \
 // RUN:     --module=- \
 // RUN:     --function=main \
-// RUN:     --input=1x2x8xi8=1 \
+// RUN:     --input=2x8xi8=1 \
 // RUN:     --input=8x4xi8=2 --xnnpack_thread_count=2 | \
 // RUN: FileCheck %s --check-prefix=CHECK-SYSTEM
 
 // CHECK-SYSTEM: EXEC @main
-// CHECK-SYSTEM: 1x2x4xf32={{\[}}[16 16 16 16][16 16 16 16]]
-func.func @main(%input : tensor<1x2x8xi8>, %kernel : tensor<8x4xi8>) -> tensor<1x2x4xf32> {
+// CHECK-SYSTEM: 2x4xf32=[16 16 16 16][16 16 16 16]
+func.func @main(%input : tensor<2x8xi8>, %kernel : tensor<8x4xi8>) -> tensor<2x4xf32> {
   // XNNPACK expects the `kernel` tensor to have unsigned values with
   // zero point of 8. The XOR operation transforms the `kernel` tensor
   // from having zero point of 0 to having zero point of 8 (i.e. going
@@ -18,6 +20,6 @@ func.func @main(%input : tensor<1x2x8xi8>, %kernel : tensor<8x4xi8>) -> tensor<1
   %c8 = stablehlo.constant dense<8> : tensor<8x4xi8>
   %kernel_adjusted = stablehlo.xor %kernel, %c8 : (tensor<8x4xi8>, tensor<8x4xi8>) -> tensor<8x4xi8>
   %kernel_i4 = stablehlo.convert %kernel_adjusted : (tensor<8x4xi8>) -> tensor<8x4xi4>
-  %c = xnnpack.fully_connected_nc_qd8_f32_qc4w %input, %kernel_i4 transpose_rhs = true : (tensor<1x2x8xi8>, tensor<8x4xi4>) -> tensor<1x2x4xf32>
-  func.return %c : tensor<1x2x4xf32>
+  %c = xnnpack.fully_connected_nc_qd8_f32_qc4w %input, %kernel_i4 transpose_rhs = true : (tensor<2x8xi8>, tensor<8x4xi4>) -> tensor<2x4xf32>
+  func.return %c : tensor<2x4xf32>
 }

--- a/samples/compiler_plugins/xnnpack/test/mul2-1d-e2e.mlir
+++ b/samples/compiler_plugins/xnnpack/test/mul2-1d-e2e.mlir
@@ -1,4 +1,6 @@
-// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --iree-plugin=xnnpack %s | \
+// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --iree-plugin=xnnpack --compile-to=flow %s | \
+// RUN: iree-opt --inline | \
+// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --compile-from=flow - | \
 // RUN: iree-run-module \
 // RUN:     --device=local-sync \
 // RUN:     --executable_plugin=$IREE_BINARY_DIR/samples/custom_dispatch/xnnpack/plugin/system_plugin$IREE_DYLIB_EXT \
@@ -19,7 +21,7 @@
 // CHECK-SYSTEM: mul2[6](2 * 4 = 8)
 // CHECK-SYSTEM: mul2[7](2 * 4 = 8)
 // CHECK-SYSTEM: 8xf32=8 8 8 8 8 8 8 8
-func.func @main(%a : tensor<?xf32>, %b : tensor<?xf32>) -> tensor<?xf32> {
-  %c = xnnpack.multiply2 %a, %b : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
-  func.return %c : tensor<?xf32>
+func.func @main(%a : tensor<8xf32>, %b : tensor<8xf32>) -> tensor<8xf32> {
+  %c = xnnpack.multiply2 %a, %b : (tensor<8xf32>, tensor<8xf32>) -> tensor<8xf32>
+  func.return %c : tensor<8xf32>
 }

--- a/samples/compiler_plugins/xnnpack/test/stablehlo-to-xnnpack-using-pdll.mlir
+++ b/samples/compiler_plugins/xnnpack/test/stablehlo-to-xnnpack-using-pdll.mlir
@@ -13,12 +13,12 @@ func.func @multiply(%a : tensor<100x200xi8>, %b : tensor<100x200xi8>) -> tensor<
 }
 
 // CHECK-LABEL:   func.func @fully_connected(
-// CHECK-SAME:                           %[[LHS:.*]]: tensor<1x100x200xi8>,
-// CHECK-SAME:                           %[[RHS:.*]]: tensor<300x200xi4>) -> tensor<1x100x300xf32> {
-// CHECK:           %{{.*}} = xnnpack.fully_connected_nc_qd8_f32_qc4w %[[LHS]], %[[RHS]] transpose_rhs = false : (tensor<1x100x200xi8>, tensor<300x200xi4>) -> tensor<1x100x300xf32>
-func.func @fully_connected(%input : tensor<1x100x200xi8>, %weight : tensor<300x200xi4>) -> tensor<1x100x300xf32> {
+// CHECK-SAME:                           %[[LHS:.*]]: tensor<100x200xi8>,
+// CHECK-SAME:                           %[[RHS:.*]]: tensor<300x200xi4>) -> tensor<100x300xf32> {
+// CHECK:           %{{.*}} = xnnpack.fully_connected_nc_qd8_f32_qc4w %[[LHS]], %[[RHS]] transpose_rhs = false : (tensor<100x200xi8>, tensor<300x200xi4>) -> tensor<100x300xf32>
+func.func @fully_connected(%input : tensor<100x200xi8>, %weight : tensor<300x200xi4>) -> tensor<100x300xf32> {
   %weight_cast = stablehlo.convert %weight : (tensor<300x200xi4>) -> tensor<300x200xi8>
-  %dot_general = stablehlo.dot_general %input, %weight_cast, contracting_dims = [2] x [1], precision = [DEFAULT, DEFAULT] : (tensor<1x100x200xi8>, tensor<300x200xi8>) -> tensor<1x100x300xi32>
-  %out = stablehlo.convert %dot_general : (tensor<1x100x300xi32>) -> tensor<1x100x300xf32>
-  return %out : tensor<1x100x300xf32>
+  %dot_general = stablehlo.dot_general %input, %weight_cast, contracting_dims = [1] x [1], precision = [DEFAULT, DEFAULT] : (tensor<100x200xi8>, tensor<300x200xi8>) -> tensor<100x300xi32>
+  %out = stablehlo.convert %dot_general : (tensor<100x300xi32>) -> tensor<100x300xf32>
+  return %out : tensor<100x300xf32>
 }

--- a/samples/compiler_plugins/xnnpack/test/stablehlo-to-xnnpack.mlir
+++ b/samples/compiler_plugins/xnnpack/test/stablehlo-to-xnnpack.mlir
@@ -1,29 +1,45 @@
 // RUN: iree-opt --iree-plugin=xnnpack --iree-print-plugin-info --pass-pipeline='builtin.module(iree-stablehlo-to-xnnpack)' %s | FileCheck %s
 
 // CHECK-LABEL:   func.func @fully_connected(
-// CHECK-SAME:                           %[[LHS:.*]]: tensor<1x100x200xi8>,
-// CHECK-SAME:                           %[[RHS:.*]]: tensor<300x200xi4>) -> tensor<1x100x300xf32> {
+// CHECK-SAME:                           %[[LHS:.*]]: tensor<100x200xi8>,
+// CHECK-SAME:                           %[[RHS:.*]]: tensor<300x200xi4>) -> tensor<100x300xf32> {
 // CHECK:           %[[C8:.*]] = stablehlo.constant dense<8>
 // CHECK:           %[[C8_I4:.*]] = stablehlo.convert %[[C8]] : (tensor<{{.*}}i8>) -> tensor<{{.*}}i4>
 // CHECK:           %[[RHS_UI4:.*]] = stablehlo.xor %[[RHS]], %[[C8_I4]]
-// CHECK:           %{{.*}} = xnnpack.fully_connected_nc_qd8_f32_qc4w %[[LHS]], %[[RHS_UI4]] transpose_rhs = false : (tensor<1x100x200xi8>, tensor<300x200xi4>) -> tensor<1x100x300xf32>
-func.func @fully_connected(%input : tensor<1x100x200xi8>, %kernel : tensor<300x200xi4>) -> tensor<1x100x300xf32> {
+// CHECK:           %{{.*}} = xnnpack.fully_connected_nc_qd8_f32_qc4w %[[LHS]], %[[RHS_UI4]] transpose_rhs = false : (tensor<100x200xi8>, tensor<300x200xi4>) -> tensor<100x300xf32>
+func.func @fully_connected(%input : tensor<100x200xi8>, %kernel : tensor<300x200xi4>) -> tensor<100x300xf32> {
   %kernel_cast = stablehlo.convert %kernel : (tensor<300x200xi4>) -> tensor<300x200xi8>
-  %dot_general = stablehlo.dot_general %input, %kernel_cast, contracting_dims = [2] x [1], precision = [DEFAULT, DEFAULT] : (tensor<1x100x200xi8>, tensor<300x200xi8>) -> tensor<1x100x300xi32>
-  %out = stablehlo.convert %dot_general : (tensor<1x100x300xi32>) -> tensor<1x100x300xf32>
-  return %out : tensor<1x100x300xf32>
+  %dot_general = stablehlo.dot_general %input, %kernel_cast, contracting_dims = [1] x [1], precision = [DEFAULT, DEFAULT] : (tensor<100x200xi8>, tensor<300x200xi8>) -> tensor<100x300xi32>
+  %out = stablehlo.convert %dot_general : (tensor<100x300xi32>) -> tensor<100x300xf32>
+  return %out : tensor<100x300xf32>
 }
 
 // CHECK-LABEL:   func.func @fully_connected$transpose(
-// CHECK-SAME:                                     %[[LHS:.*]]: tensor<1x100x200xi8>,
-// CHECK-SAME:                                     %[[RHS:.*]]: tensor<200x300xi4>) -> tensor<1x100x300xf32> {
+// CHECK-SAME:                                     %[[LHS:.*]]: tensor<100x200xi8>,
+// CHECK-SAME:                                     %[[RHS:.*]]: tensor<200x300xi4>) -> tensor<100x300xf32> {
 // CHECK:           %[[C8:.*]] = stablehlo.constant dense<8>
 // CHECK:           %[[C8_I4:.*]] = stablehlo.convert %[[C8]] : (tensor<{{.*}}xi8>) -> tensor<{{.*}}xi4>
 // CHECK:           %[[RHS_UI4:.*]] = stablehlo.xor %[[RHS]], %[[C8_I4]]
-// CHECK:           %{{.*}} = xnnpack.fully_connected_nc_qd8_f32_qc4w %[[LHS]], %[[RHS_UI4]] transpose_rhs = true : (tensor<1x100x200xi8>, tensor<200x300xi4>) -> tensor<1x100x300xf32>
-func.func @fully_connected$transpose(%input : tensor<1x100x200xi8>, %kernel : tensor<200x300xi4>) -> tensor<1x100x300xf32> {
+// CHECK:           %{{.*}} = xnnpack.fully_connected_nc_qd8_f32_qc4w %[[LHS]], %[[RHS_UI4]] transpose_rhs = true : (tensor<100x200xi8>, tensor<200x300xi4>) -> tensor<100x300xf32>
+func.func @fully_connected$transpose(%input : tensor<100x200xi8>, %kernel : tensor<200x300xi4>) -> tensor<100x300xf32> {
   %kernel_cast = stablehlo.convert %kernel : (tensor<200x300xi4>) -> tensor<200x300xi8>
-  %dot_general = stablehlo.dot_general %input, %kernel_cast, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<1x100x200xi8>, tensor<200x300xi8>) -> tensor<1x100x300xi32>
+  %dot_general = stablehlo.dot_general %input, %kernel_cast, contracting_dims = [1] x [0], precision = [DEFAULT, DEFAULT] : (tensor<100x200xi8>, tensor<200x300xi8>) -> tensor<100x300xi32>
+  %out = stablehlo.convert %dot_general : (tensor<100x300xi32>) -> tensor<100x300xf32>
+  return %out : tensor<100x300xf32>
+}
+
+// CHECK-LABEL:   func.func @fully_connected$rank3_input(
+// CHECK-SAME:                           %[[LHS:.*]]: tensor<1x100x200xi8>,
+// CHECK-SAME:                           %[[RHS:.*]]: tensor<300x200xi4>) -> tensor<1x100x300xf32> {
+// CHECK:           %[[C8:.*]] = stablehlo.constant dense<8>
+// CHECK:           %[[LHS_RESHAPE:.*]] = stablehlo.reshape %[[LHS]] : (tensor<1x100x200xi8>) -> tensor<100x200xi8>
+// CHECK:           %[[C8_I4:.*]] = stablehlo.convert %[[C8]] : (tensor<{{.*}}i8>) -> tensor<{{.*}}i4>
+// CHECK:           %[[RHS_UI4:.*]] = stablehlo.xor %[[RHS]], %[[C8_I4]]
+// CHECK:           %[[FULLY_CONNECTED:.*]] = xnnpack.fully_connected_nc_qd8_f32_qc4w %[[LHS_RESHAPE]], %[[RHS_UI4]] transpose_rhs = false : (tensor<100x200xi8>, tensor<300x200xi4>) -> tensor<100x300xf32>
+// CHECK:           %{{.*}} = stablehlo.reshape %[[FULLY_CONNECTED]] : (tensor<100x300xf32>) -> tensor<1x100x300xf32>
+func.func @fully_connected$rank3_input(%input : tensor<1x100x200xi8>, %kernel : tensor<300x200xi4>) -> tensor<1x100x300xf32> {
+  %kernel_cast = stablehlo.convert %kernel : (tensor<300x200xi4>) -> tensor<300x200xi8>
+  %dot_general = stablehlo.dot_general %input, %kernel_cast, contracting_dims = [2] x [1], precision = [DEFAULT, DEFAULT] : (tensor<1x100x200xi8>, tensor<300x200xi8>) -> tensor<1x100x300xi32>
   %out = stablehlo.convert %dot_general : (tensor<1x100x300xi32>) -> tensor<1x100x300xf32>
   return %out : tensor<1x100x300xf32>
 }

--- a/samples/compiler_plugins/xnnpack/test/xnnpack-legalize.mlir
+++ b/samples/compiler_plugins/xnnpack/test/xnnpack-legalize.mlir
@@ -44,23 +44,23 @@ func.func @batch_matrix_multiply(%a : tensor<?x?x?xf32>, %b : tensor<?x?x?xf32>)
 // -----
 
 // CHECK-LABEL:   func.func private @xnnpack.fully_connected_nc_qd8_f32_qc4w_0(
-// CHECK-SAME:                                                               %[[A:.*]]: tensor<1x?x?xi8>,
-// CHECK-SAME:                                                               %[[B:.*]]: tensor<?x?xi4>) -> tensor<1x?x?xf32> {
-// CHECK:           %[[OUT:.*]] = tensor.empty(%[[A_DIM_1:.*]], %[[B_DIM_0:.*]]) : tensor<1x?x?xf32>
-// CHECK:           %[[RESULT:.*]] = flow.dispatch.region -> (tensor<1x?x?xf32>{%[[A_DIM_1]], %[[B_DIM_0]]}) {
-// CHECK:             %[[UKERNEL:.*]] = iree_codegen.ukernel.generic "xnnpack.fully_connected_nc_qd8_f32_qc4w_workgroup" ins(%[[A]], %[[B]] : tensor<1x?x?xi8>, tensor<?x?xi4>) outs(%[[OUT]] : tensor<1x?x?xf32>) (%[[A_DIM_0:.*]], %[[A_DIM_1]], %[[A_DIM_2:.*]], %[[B_DIM_0]], %[[B_DIM_1:.*]], %[[A_DIM_0]], %[[A_DIM_1]], %[[B_DIM_0]], %[[TRANSPOSE_RHS:.*]] : index, index, index, index, index, index, index, index, i8) -> tensor<1x?x?xf32>
-// CHECK:             flow.return %[[UKERNEL]] : tensor<1x?x?xf32>
+// CHECK-SAME:                                                               %[[A:.*]]: tensor<?x?xi8>,
+// CHECK-SAME:                                                               %[[B:.*]]: tensor<?x?xi4>) -> tensor<?x?xf32> {
+// CHECK:           %[[OUT:.*]] = tensor.empty(%[[A_DIM_0:.*]], %[[B_DIM_0:.*]]) : tensor<?x?xf32>
+// CHECK:           %[[RESULT:.*]] = flow.dispatch.region -> (tensor<?x?xf32>{%[[A_DIM_0]], %[[B_DIM_0]]}) {
+// CHECK:             %[[UKERNEL:.*]] = iree_codegen.ukernel.generic "xnnpack.fully_connected_nc_qd8_f32_qc4w_workgroup" ins(%[[A]], %[[B]] : tensor<?x?xi8>, tensor<?x?xi4>) outs(%[[OUT]] : tensor<?x?xf32>) (%[[A_DIM_0]], %[[A_DIM_1:.*]], %[[B_DIM_0]], %[[B_DIM_1:.*]], %[[A_DIM_0]], %[[B_DIM_0]], %[[TRANSPOSE_RHS:.*]] : index, index, index, index, index, index, i8) -> tensor<?x?xf32>
+// CHECK:             flow.return %[[UKERNEL]] : tensor<?x?xf32>
 // CHECK:           } count() -> (index, index, index) {
 // CHECK:             %[[ONE:.*]] = arith.constant 1 : index
 // CHECK:             flow.return %[[ONE]], %[[ONE]], %[[ONE]] : index, index, index
 // CHECK:           }
-// CHECK:           return %[[RESULT]] : tensor<1x?x?xf32>
+// CHECK:           return %[[RESULT]] : tensor<?x?xf32>
 
 // CHECK-LABEL:   func.func @fully_connected(
 // CHECK:           %{{.*}} = call @xnnpack.fully_connected_nc_qd8_f32_qc4w_0
-func.func @fully_connected(%a : tensor<1x?x?xi8>, %b : tensor<?x?xi4>) -> tensor<1x?x?xf32> {
-  %c = xnnpack.fully_connected_nc_qd8_f32_qc4w %a, %b transpose_rhs = false : (tensor<1x?x?xi8>, tensor<?x?xi4>) -> tensor<1x?x?xf32>
-  func.return %c : tensor<1x?x?xf32>
+func.func @fully_connected(%a : tensor<?x?xi8>, %b : tensor<?x?xi4>) -> tensor<?x?xf32> {
+  %c = xnnpack.fully_connected_nc_qd8_f32_qc4w %a, %b transpose_rhs = false : (tensor<?x?xi8>, tensor<?x?xi4>) -> tensor<?x?xf32>
+  func.return %c : tensor<?x?xf32>
 }
 
 // -----
@@ -71,10 +71,10 @@ func.func @fully_connected(%a : tensor<1x?x?xi8>, %b : tensor<?x?xi4>) -> tensor
 // CHECK-LABEL:   func.func @fully_connected$multiple_static(
 // CHECK:           %{{.*}} = call @xnnpack.fully_connected_nc_qd8_f32_qc4w_0
 // CHECK:           %{{.*}} = call @xnnpack.fully_connected_nc_qd8_f32_qc4w_1
-func.func @fully_connected$multiple_static(%input_0 : tensor<1x2x8xi8>, %kernel_0 : tensor<4x8xi4>,
-                                           %input_1 : tensor<1x2x16xi8>, %kernel_1 : tensor<4x16xi4>)
-                                           -> (tensor<1x2x4xf32>, tensor<1x2x4xf32>) {
-  %output_0 = xnnpack.fully_connected_nc_qd8_f32_qc4w %input_0, %kernel_0 transpose_rhs = false : (tensor<1x2x8xi8>, tensor<4x8xi4>) -> tensor<1x2x4xf32>
-  %output_1 = xnnpack.fully_connected_nc_qd8_f32_qc4w %input_1, %kernel_1 transpose_rhs = false : (tensor<1x2x16xi8>, tensor<4x16xi4>) -> tensor<1x2x4xf32>
-  func.return %output_0, %output_1 : tensor<1x2x4xf32>, tensor<1x2x4xf32>
+func.func @fully_connected$multiple_static(%input_0 : tensor<2x8xi8>, %kernel_0 : tensor<4x8xi4>,
+                                           %input_1 : tensor<2x16xi8>, %kernel_1 : tensor<4x16xi4>)
+                                           -> (tensor<2x4xf32>, tensor<2x4xf32>) {
+  %output_0 = xnnpack.fully_connected_nc_qd8_f32_qc4w %input_0, %kernel_0 transpose_rhs = false : (tensor<2x8xi8>, tensor<4x8xi4>) -> tensor<2x4xf32>
+  %output_1 = xnnpack.fully_connected_nc_qd8_f32_qc4w %input_1, %kernel_1 transpose_rhs = false : (tensor<2x16xi8>, tensor<4x16xi4>) -> tensor<2x4xf32>
+  func.return %output_0, %output_1 : tensor<2x4xf32>, tensor<2x4xf32>
 }


### PR DESCRIPTION
This commit restricts the fully connected op of XNNPACK to only take 2d inputs and produce a 2d output. This matches the semantics of the op in the XNNPACK library. In order to keep the 3d input/output support with batch-size of 1, reshape ops are inserted before and after the op.

The insertion of reshape operations leads to a compiler error regarding the hoisting of global variables. The errors turns out to be due to poor handling of function calls by the IREE compiler. If an `inline` pass is inserted right after reaching the `flow` dialect, all errors regarding hoisting and consteval go away. Therefore, this commit also changes the lit tests to include an `inline` pass after reaching the `flow` level (adding the `inline` causes issues when sizes are dynamic, so the tests are restricted to static shapes for now).

Note: currently there is no simple way to add passes after the `flow` level from the compiler plugin, so the lit tests do it manually. Future work will include moving this change to the pipeline to the compiler plugin.