### PR TITLE
Add inline pass at the end of flow pipeline

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -277,6 +277,14 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
 
   passManager.addNestedPass<IREE::Flow::ExecutableOp>(
       mlir::createCanonicalizerPass());
+  // IREE currently has poor handling of function calls in the IR, resulting in
+  // compilation errors when the XNNPACK compiler plugin is used with some
+  // models. Since compiler plugins can only modify the preprocessing
+  // pipeline, it is not possible to perform the inline pass at the right moment
+  // from the compiler plugin side.
+  // TODO: Add support for modifying all pipelines from the compiler plugin
+  // registration code.
+  passManager.addPass(mlir::createInlinerPass());
   passManager.addNestedPass<IREE::Flow::ExecutableOp>(mlir::createCSEPass());
 
   // Symbol DCE any remaining variables/functions that are now no longer

--- a/samples/compiler_plugins/xnnpack/test/batch-matrix-multiply-e2e.mlir
+++ b/samples/compiler_plugins/xnnpack/test/batch-matrix-multiply-e2e.mlir
@@ -1,6 +1,4 @@
-// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --iree-plugin=xnnpack --compile-to=flow %s | \
-// RUN: iree-opt --inline | \
-// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --compile-from=flow - | \
+// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --iree-plugin=xnnpack %s | \
 // RUN: iree-run-module \
 // RUN:     --device=local-sync \
 // RUN:     --executable_plugin=$IREE_BINARY_DIR/samples/custom_dispatch/xnnpack/plugin/system_plugin$IREE_DYLIB_EXT \

--- a/samples/compiler_plugins/xnnpack/test/fully-connected-e2e.mlir
+++ b/samples/compiler_plugins/xnnpack/test/fully-connected-e2e.mlir
@@ -1,6 +1,4 @@
-// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --iree-plugin=xnnpack --compile-to=flow %s | \
-// RUN: iree-opt --inline | \
-// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --compile-from=flow - | \
+// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --iree-plugin=xnnpack %s | \
 // RUN: iree-run-module \
 // RUN:     --device=local-sync \
 // RUN:     --executable_plugin=$IREE_BINARY_DIR/samples/custom_dispatch/xnnpack/plugin/system_plugin$IREE_DYLIB_EXT \

--- a/samples/compiler_plugins/xnnpack/test/fully-connected-transpose-e2e.mlir
+++ b/samples/compiler_plugins/xnnpack/test/fully-connected-transpose-e2e.mlir
@@ -1,6 +1,4 @@
-// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --iree-plugin=xnnpack --compile-to=flow %s | \
-// RUN: iree-opt --inline | \
-// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --compile-from=flow - | \
+// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --iree-plugin=xnnpack %s | \
 // RUN: iree-run-module \
 // RUN:     --device=local-sync \
 // RUN:     --executable_plugin=$IREE_BINARY_DIR/samples/custom_dispatch/xnnpack/plugin/system_plugin$IREE_DYLIB_EXT \

--- a/samples/compiler_plugins/xnnpack/test/mul2-1d-e2e.mlir
+++ b/samples/compiler_plugins/xnnpack/test/mul2-1d-e2e.mlir
@@ -1,6 +1,4 @@
-// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --iree-plugin=xnnpack --compile-to=flow %s | \
-// RUN: iree-opt --inline | \
-// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --compile-from=flow - | \
+// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --iree-plugin=xnnpack %s | \
 // RUN: iree-run-module \
 // RUN:     --device=local-sync \
 // RUN:     --executable_plugin=$IREE_BINARY_DIR/samples/custom_dispatch/xnnpack/plugin/system_plugin$IREE_DYLIB_EXT \


### PR DESCRIPTION
IREE currently has poor handling of function calls. Since the XNNPACK compiler plugin currently inserts `ukernel.generic` ops, which then get turned into function calls during the Flow pipeline, we need to inline the calls at the end of the pipeline to avoid errors when executing the Stream pipeline. This commit adds the inline pass towards the end of the Flow pipeline.